### PR TITLE
Add oblivion-theory bridge projection package (refs #25)

### DIFF
--- a/lean4/Omega.lean
+++ b/lean4/Omega.lean
@@ -91,6 +91,7 @@ import Omega.SPG.ProuhetThueMorsePowerSum
 import Omega.SPG.SingleParamLogReadoutPigeonhole
 import Omega.SPG.BoundaryCycleAuditQueryLowerBound
 import Omega.Frontier.Assumptions
+import Omega.Frontier.OblivionBridge
 import Omega.Frontier.Conditional
 import Omega.Frontier.ConditionalSPG
 import Omega.Frontier.ConditionalArithmetic

--- a/lean4/Omega/Frontier/OblivionBridge.lean
+++ b/lean4/Omega/Frontier/OblivionBridge.lean
@@ -1,0 +1,64 @@
+import Omega.Folding.Defect
+
+namespace Omega.Frontier
+
+/-- Projection-only discretization shadow used by the oblivion bridge.
+    This is the strict 1-functor part of the candidate bridge. -/
+def discretizeProjMap (h : m ≤ n) : X n → X m :=
+  X.restrictLE h
+
+@[simp] theorem discretizeProjMap_apply (h : m ≤ n) (x : X n) :
+    discretizeProjMap h x = X.restrictLE h x :=
+  rfl
+
+@[simp] theorem discretizeProj_id (x : X n) :
+    discretizeProjMap (Nat.le_refl n) x = x := by
+  simp [discretizeProjMap]
+
+/-- Projection-only discretization is strictly functorial on coordinate restriction maps.
+    This is the certified strict part of the oblivion bridge.
+    thm:oblivion-bridge-projection-functorial -/
+theorem discretizeProj_comp (h₁ : m ≤ n) (h₂ : n ≤ k) (x : X k) :
+    discretizeProjMap h₁ (discretizeProjMap h₂ x) =
+      discretizeProjMap (Nat.le_trans h₁ h₂) x := by
+  simpa [discretizeProjMap] using X.restrict_functorial h₁ h₂ x
+
+/-- Function-level version of the strict projection functoriality. -/
+theorem discretize_proj_functorial (h₁ : m ≤ n) (h₂ : n ≤ k) :
+    discretizeProjMap h₁ ∘ discretizeProjMap h₂ =
+      discretizeProjMap (Nat.le_trans h₁ h₂) := by
+  funext x
+  exact discretizeProj_comp h₁ h₂ x
+
+/-- The bridge is not strictly monoidal at finite resolution; its coherence datum is the
+    carry defect cocycle already formalized in `globalDefect_compose`.
+    thm:oblivion-bridge-defect-two-cell -/
+theorem discretizeProj_defect_two_cell (hmk : m ≤ k) (hkn : k ≤ n) (ω : Word n) :
+    globalDefect (Nat.le_trans hmk hkn) ω =
+      xorWord
+        (globalDefect hmk (restrictWord hkn ω))
+        (restrictWord hmk (globalDefect hkn ω)) :=
+  globalDefect_compose hmk hkn ω
+
+/-- Adjacent-scale form of the defect two-cell, useful for bridge diagrams. -/
+theorem discretizeProj_poincare_band (hmn : m + 1 ≤ n) (ω : Word n) :
+    globalDefect (Nat.le_trans (Nat.le_succ m) hmn) ω =
+      xorWord
+        (globalDefect (Nat.le_succ m) (restrictWord hmn ω))
+        (restrictWord (Nat.le_succ m) (globalDefect hmn ω)) :=
+  globalDefect_poincare_band hmn ω
+
+/-- Compact package for the current certified bridge surface:
+    strict projection functoriality plus the defect-bearing coherence law.
+    thm:oblivion-bridge-projection-package -/
+theorem paper_oblivion_bridge_projection_package
+    (h₁ : m₁ ≤ m₂) (h₂ : m₂ ≤ m₃) (x : X m₃) (ω : Word m₃) :
+    discretizeProjMap h₁ (discretizeProjMap h₂ x) =
+        discretizeProjMap (Nat.le_trans h₁ h₂) x ∧
+      globalDefect (Nat.le_trans h₁ h₂) ω =
+        xorWord
+          (globalDefect h₁ (restrictWord h₂ ω))
+          (restrictWord h₁ (globalDefect h₂ ω)) := by
+  exact ⟨discretizeProj_comp h₁ h₂ x, discretizeProj_defect_two_cell h₁ h₂ ω⟩
+
+end Omega.Frontier

--- a/theory/bridges/oblivion-theory/README.md
+++ b/theory/bridges/oblivion-theory/README.md
@@ -1,0 +1,64 @@
+# Oblivion Bridge: Projection Functoriality and Defect Coherence
+
+This directory collects bridge-facing material for the candidate oblivion-theory connection discussed in [issue #25](https://github.com/the-omega-institute/automath/issues/25).
+
+## Current certified surface
+
+The bridge problem splits into three layers.
+
+1. Strict projection functoriality
+2. Discrete differential target (`deltaSet` / Walsh-Stokes side)
+3. Defect-bearing monoidal coherence
+
+Inside this repository, the first and third layers are already certified as Lean theorems. The second layer is only pointed to, not wrapped by the new bridge module.
+
+## Lean anchors
+
+The bridge-facing Lean wrapper lives at:
+
+- `lean4/Omega/Frontier/OblivionBridge.lean`
+
+It exposes the following theorems.
+
+- `Omega.Frontier.discretizeProj_comp`
+  - strict functoriality of the projection-only discretization shadow on stable words
+  - backed by `Omega.X.restrict_functorial`
+- `Omega.Frontier.discretize_proj_functorial`
+  - function-level restatement of the same strict part
+- `Omega.Frontier.discretizeProj_defect_two_cell`
+  - the defect cocycle law for the bridge-facing coherence datum
+  - backed by `Omega.globalDefect_compose`
+- `Omega.Frontier.discretizeProj_poincare_band`
+  - adjacent-scale form of the same coherence law
+- `Omega.Frontier.paper_oblivion_bridge_projection_package`
+  - compact package theorem: strict projection functoriality plus defect cocycle
+
+## What is now justified
+
+The candidate bridge already has a certified strict core on coordinate projections. In that restricted sense, the composition law is not open anymore.
+
+What remains open is not ordinary functoriality, but higher coherence:
+
+- whether the continuous-side composition/addition drift can be identified with the discrete carry defect
+- whether the bridge should be organized as a lax monoidal functor, pseudofunctor, or another defect-bearing 2-categorical object
+
+The discrete differential target is still available in the core library through:
+
+- `Omega.Core.deltaBit_comm`
+- `Omega.Core.walshStokes_finset`
+
+## Non-claims
+
+This directory does **not** claim any of the following.
+
+- a canonical full functor `Man -> Hyp` for arbitrary smooth morphisms
+- a complete Lean formalization of the continuous-side chain map
+- an established equality between curvature/drift and the automath carry cocycle
+
+## Suggested PR shape
+
+If this material is turned into a PR, the smallest honest claim is:
+
+1. Add the projection-only strict bridge theorems.
+2. Explicitly separate strict functoriality from defect-bearing coherence.
+3. Leave the continuous obstruction-class identification as the actual open problem.


### PR DESCRIPTION
Adds the first certified bridge surface for the oblivion-theory connection discussed in #25.

### What this adds

- `lean4/Omega/Frontier/OblivionBridge.lean` — strict projection functoriality + defect cocycle coherence, wrapping `X.restrict_functorial` and `globalDefect_compose`
- `theory/bridges/oblivion-theory/README.md` — certified surface and open problem boundaries, following the precision-label convention from #25
- `lean4/Omega.lean` — import wiring

### Smallest honest claim

- Restriction along the resolution tower is strictly functorial.
- The fold defect satisfies a coherent xor-cocycle composition law.

### Explicit non-claims

- No canonical full functor `Man -> Hyp` for arbitrary smooth morphisms
- No complete Lean formalization of the continuous-side chain map
- No established equality between curvature/drift and the automath carry cocycle

### Build

`lake build Omega.Frontier.OblivionBridge` was verified on this exact commit against a fresh local clone (all 3115 jobs green, no warnings).

Refs: #25