### PR TITLE
Update conclusion section with boundary detector and parity stack rigidity results

### DIFF
--- a/theory/2026_golden_ratio_driven_scan_projection_generation_recursive_emergence/sections/body/conclusion/main.tex
+++ b/theory/2026_golden_ratio_driven_scan_projection_generation_recursive_emergence/sections/body/conclusion/main.tex
@@ -4,6 +4,8 @@
 \input{sec__conclusion}
 \input{subsec__conclusion-prime-register-semidirect-godel-geometry}
 \input{subsec__conclusion-bounded-prime-register-godel-scaling}
+\input{subsec__conclusion-prime-register-ramanujan-shadow-budget-localization-blindness}
+\input{subsec__conclusion-finite-primesupport-boolean-exact-uniaxial-register}
 \input{subsec__conclusion-primorial-prefix-golden-tail-replay-strongconverse}
 \input{subsec__conclusion-lucas-hankel-discriminant-rigidity}
 \input{thm__conclusion-lucas-charp-shifted-hankel-geometric-ratio}
@@ -45,6 +47,7 @@
 \input{subsec__conclusion-jensen-repulsion-cofinal-certificate-complexity-bifurcation}
 \input{subsec__conclusion-xi-dyadic-recursion-zero-stability}
 \input{subsec__conclusion-phase-prefix-mellin-transverse-gabcke-rigidity}
+\input{subsec__conclusion-phase-gram-mellin-hardy-radial-rigidity}
 \input{subsec__conclusion-criticalslice-radial-prefix-prime-ledger-normalform}
 \input{subsec__conclusion-aperiodic-critical-rigidity-multiscale-ledger}
 \input{subsec__conclusion-multiscale-stokes-energy-sampling}
@@ -126,6 +129,7 @@
 \input{subsec__conclusion-zg-pointwise-boundary-twochannel-orthogonality}
 \input{subsec__conclusion-prime-log-calibration-operator-boundary-current-rh}
 \input{subsec__conclusion-prime-log-coboundary-pressure-abel-mellin-rigidity}
+\input{subsec__conclusion-solenoid-poissoncauchy-primelog-finitecomb-canonical-nogo}
 \input{subsec__conclusion-cdim-externalization-signature-singlephase-precision}
 \input{subsec__conclusion-fiber-intermediate-systems-mobius-correction}
 \input{subsec__conclusion-fold-groupoid-matrixunit-normalizer-parity}
@@ -145,6 +149,7 @@
 \input{subsec__conclusion-foldbin-faithful-dimension-fullinversion-obstruction}
 \input{subsec__conclusion-foldbin-stable-k0-faithful-boundary-parity-groupoid}
 \input{subsec__conclusion-foldbin-center-zeta-fibonacci-measure-rigidity}
+\input{subsec__conclusion-window6-boundary-detector-sideinfo-stack-rigidity}
 \input{subsec__conclusion-fibadic-haar-randomdepth-binfold-conjugacy-schur}
 \input{subsec__conclusion-max-noncontractible-fiber-zero-block-golden-coupling}
 \input{subsec__conclusion-foldbin-critical-capacity-likelihood-neyman-pearson}
@@ -161,10 +166,12 @@
 \input{subsec__conclusion-fullresidue-simplex-sufficient-externalization-collapse}
 \input{subsec__conclusion-capacity-mellin-thermodynamic-wedderburn-holography}
 \input{subsec__conclusion-capacity-majorization-infonce-complexity-separation}
+\input{subsec__conclusion-freezing-capacity-samplepattern-audit-register-trisplitting}
 \input{subsec__conclusion-foldbin-multiplicity-mellin-dirichlet-kernel}
 \input{subsec__conclusion-bernoulli-zeta-moment-truncation-pearson-abel-arithmetic-splitting}
 \input{subsec__conclusion-residue-local-bias-kernel-blindmode-resonance}
 \input{subsec__conclusion-finite-defect-fourier-laplace-jet-tomography}
+\input{subsec__conclusion-hiddenchannel-boundarycarrier-finitejet-schur-median-rigidity}
 \input{subsec__conclusion-secondwindow-ae-threshold-temperature-budget-duality}
 \input{subsec__conclusion-maxfiber-average-scale-rigidity}
 \input{subsec__conclusion-freezing-taillaw-noncontractible-mod6-splitting}
@@ -176,7 +183,9 @@
 \input{subsec__conclusion-golden-resonance-cartwright-finite-contact}
 \input{subsec__conclusion-escort-criticalfield-hankel-padic-rigidity}
 \input{subsec__conclusion-infonce-freezing-fourier-maxfiber-three-exponent-splitting}
+\input{subsec__conclusion-fiber-audit-hodge-congruence-reversible-trisplitting}
 \input{subsec__conclusion-microescort-freezing-oracle-bitrate-separation}
+\input{subsec__conclusion-capacity-holography-parity-freezing-contrastive-bifurcation}
 \input{subsec__conclusion-window6-sheet-parity-watatani-crossedproduct-freeze-capacity}
 \input{subsec__conclusion-foldbin-staircase-window6-golden-twist-rigidity}
 \input{subsec__conclusion-window6-fixedfreezing-shortlong-escort-weyl}
@@ -191,6 +200,7 @@
 \input{subsec__conclusion-artin-shadow-schur-prefix-cyclotomic-obstruction}
 \input{subsec__conclusion-artin-schur-abelian-distortion-double-register}
 \input{subsec__conclusion-window6-residual-budget-freezing-golden-constants}
+\input{subsec__conclusion-window6-foldpi-endpoint-binaryescort-minimal-hosts}
 \input{subsec__conclusion-window6-lie-topological-hybrid-phase}
 \input{subsec__conclusion-window6-pinned-torus-torsion-shadow-rigidity}
 \input{subsec__conclusion-window6-spin-minuscule-hypercube-signature}
@@ -203,12 +213,15 @@
 \input{subsec__conclusion-window6-sizebias-boundary-tail-maximality}
 \input{subsec__conclusion-window6-moment-collision-coroot-scalarization}
 \input{subsec__conclusion-window6-hidden-boundary-moment-escort-kl-floor}
+\input{subsec__conclusion-window6-boundary-rigidity-reentry-anova-externality}
+\input{thm__conclusion-window6-boundary-externality-walsh-gap}
 \input{thm__conclusion-window6-output-ramanujan-mellin-collapse}
 \input{subsec__conclusion-window6-fourier-visible-syzygy-tensor-vacuum}
 \input{subsec__conclusion-window6-cartan-syzygy-green-isotropy-codegap}
 \input{subsec__conclusion-window6-permutation-module-laplacian-reynolds}
 \input{subsec__conclusion-window6-design-adelic-determinant-statistical-separation}
 \input{subsec__conclusion-window6-cartan-dynamics-green-singleprime-faultline}
+\input{subsec__conclusion-window6-freezing-bridge-primefault-cartan-coupling}
 \input{subsec__conclusion-window6-crt-weyl-discriminant-anomaly-collision}
 \input{subsec__conclusion-window6-phase-budget-rigidity}
 \input{subsec__conclusion-window6-mod2-k0-sync-replay-boundary-face}
@@ -230,6 +243,7 @@
 \input{subsec__conclusion-screen-hypercube-boundary-torsor-shapley}
 \input{subsec__conclusion-coordinatebundle-kirchhoff-poissonbinomial-logscale}
 \input{subsec__conclusion-coordinatebundle-codimension-tree-star-kirchhoff-rigidity}
+\input{subsec__conclusion-coordinatebundle-integrable-poisson-gumbel-resistance-shapley}
 \input{subsec__conclusion-cyclelattice-affine-uv-coarsegraining-torsion-coding-rigidity}
 \input{subsec__conclusion-anisotropic-serrin-screen-flux-moment-holography}
 \input{subsec__conclusion-finitewindow-solenoid-leyang-window6-budget-splitting}
@@ -238,6 +252,8 @@
 \input{subsec__conclusion-rhsharp-comb-fredholm-solenoid-finite-witness}
 \input{subsec__conclusion-tail-twist-dual-obstruction-capacity-finitepart-jet-feedback}
 \input{subsec__conclusion-fixedresolution-collision-hankel-prony-spectrum}
+\input{subsec__conclusion-moment-determinacy-hankel-goodprime-recovery-discriminant}
+\input{subsec__conclusion-dualinterface-2d-toeplitz-prony-discriminant-badreduction}
 \input{subsec__conclusion-primestage-slowmode-rh-dual-nogo}
 \input{subsec__conclusion-orientation-torsor-supermonoidal-wreath-gauge-register}
 \input{subsec__conclusion-fold-gauge-entropy-gap-boolean-lucas-kernel}

--- a/theory/2026_golden_ratio_driven_scan_projection_generation_recursive_emergence/sections/body/conclusion/subsec__conclusion-capacity-holography-parity-freezing-contrastive-bifurcation.tex
+++ b/theory/2026_golden_ratio_driven_scan_projection_generation_recursive_emergence/sections/body/conclusion/subsec__conclusion-capacity-holography-parity-freezing-contrastive-bifurcation.tex
@@ -1,0 +1,383 @@
+\subsection{容量全息、Mellin--Dirichlet 主核、秩一奇偶盲模与冻结/对比学习的双阈值分裂}\label{subsec:conclusion-capacity-holography-parity-freezing-contrastive-bifurcation}
+沿用定理
+\ref{thm:conclusion-capacity-majorization-schur-hardness}、
+\ref{thm:conclusion-capacity-ordered-spectrum-infonce-equivalence}、
+\ref{thm:conclusion-capacity-curve-mellin-complete-reconstruction}、
+\ref{thm:conclusion-infonce-capacity-wedderburn-unified-closure}、
+\ref{thm:conclusion-foldbin-multiplicity-mellin-two-sided-unification}、
+\ref{thm:conclusion-foldbin-histogram-tower-arithmetic-topological-completeness}、
+\ref{thm:conclusion-thermodynamic-flattening-subextensive-arithmetic-rigidity}、
+\ref{thm:conclusion-residue-local-statistics-complete-reconstruction}、
+\ref{cor:conclusion-residue-mod3-local-reversibility-phase-transition}、
+\ref{cor:conclusion-residue-even-window-universal-parity-blind-mode}、
+\ref{cor:conclusion-residue-even-window-one-functional-repair}、
+\ref{thm:conclusion-zero-density-pearson-explosion-strict-separation}、
+\ref{thm:conclusion-first-coordinate-bias-energy-spectral-faithfulness}、
+\ref{cor:conclusion-first-coordinate-bias-and-global-gap-common-resonant-origin}、
+\ref{thm:conclusion-uniform-vs-frozen-micro-bitrate-separation}、
+\ref{cor:conclusion-frozen-branch-two-scalar-closure}、
+\ref{cor:conclusion-frozen-first-difference-micro-bitrate-identity}、
+\ref{cor:conclusion-uniform-frozen-micro-bitrate-gap-formula}、
+\ref{thm:conclusion-infonce-capacity-gap-kernel-representation}
+与
+\ref{thm:conclusion-infonce-second-jet-reciprocal-multiplicity}
+的记号。前述小节已经分别把连续容量曲线与主序/InfoNCE/Wedderburn 型的互逆完备性、纤维多重度 Mellin--Dirichlet 核的双侧统一、局部奇偶盲模的秩一障碍、第一坐标偏置的谱忠实性、冻结枝的双标量闭包，以及有限负样本 Bayes 最优损失的容量缺口核表示固定下来。把这些接口再作一次跨节拼接，还可抽出如下八条终端闭包。
+
+\begin{theorem}[连续容量曲线的序理论封口与有限分辨率全息普适性]\label{thm:conclusion-capacity-curve-order-holography-universality}
+固定分辨率 \(m\)，记总质量 \(S:=2^m\)、可见类型数 \(N:=|X_m|\)，并令
+\[
+d=(d_1,\dots,d_N),
+\qquad
+d_1\ge \cdots \ge d_N\ge 1,
+\qquad
+\sum_{i=1}^{N}d_i=S.
+\]
+定义连续容量曲线
+\[
+C_d(u):=\sum_{i=1}^{N}\min(d_i,u)
+\qquad (u\ge 0).
+\]
+则同时成立：
+\begin{enumerate}
+  \item
+  \[
+  d\preceq_{\mathrm{HLP}} e
+  \iff
+  C_d(u)\le C_e(u)
+  \qquad (\forall u\ge 0),
+  \]
+  即 Hardy--Littlewood--P\'olya 主序在固定总质量切片上恰由连续容量曲线的逐点序反向实现；
+  \item 以下四类数据彼此唯一决定：
+  \[
+  C_d(\cdot),
+  \qquad
+  \left(\frac{d_1}{2^m},\dots,\frac{d_N}{2^m}\right),
+  \qquad
+  \mathscr L_m:=
+  (\mathcal L_{2,m}^{\star},\dots,\mathcal L_{N,m}^{\star}),
+  \]
+  以及半单群胚代数的 Wedderburn 型
+  \[
+  A_m^{\mathrm{bin}}\cong \bigoplus_{n\ge 1}M_n(\CC)^{\oplus h_m(n)}.
+  \]
+\end{enumerate}
+因而，对任一仅依赖纤维多重集的固定分辨率不变量，连续容量曲线 \(C_d\) 已是其唯一的全息承载对象；等价地，所有此类不变量都经由 \(C_d\) 唯一因子化。
+\end{theorem}
+\begin{proof}
+第一条正是定理 \ref{thm:conclusion-capacity-majorization-schur-hardness} 的内容。第二条中，连续容量曲线与有序纤维谱、完整 Bayes--InfoNCE 数值塔之间的互逆完备性由定理 \ref{thm:conclusion-capacity-ordered-spectrum-infonce-equivalence} 给出，而完整有限负样本塔、连续容量曲线、纤维直方图与 Wedderburn 型之间的互逆完备性由定理 \ref{thm:conclusion-infonce-capacity-wedderburn-unified-closure} 给出。于是四类数据彼此唯一恢复。
+
+最后，任何仅依赖纤维多重集的不变量，本质上都是纤维直方图 \((h_m(n))_{n\ge 1}\) 的函子；既然直方图又由 \(C_d\) 唯一决定，这类不变量便都经由 \(C_d\) 唯一因子化。证毕。
+\end{proof}
+
+\begin{theorem}[Mellin--Dirichlet 主核的热力学--算术二层刚性]\label{thm:conclusion-mellin-dirichlet-master-kernel-two-layer-rigidity}
+对每个固定 \(m\)，定义纤维多重度直方图
+\[
+\nu_m(d):=\#\{x\in X_m:\ d_m(x)=d\},
+\]
+以及有限 Dirichlet 多项式
+\[
+\mathcal M_m(s):=\sum_{d\ge 1}\nu_m(d)d^{-s}.
+\]
+则 \(\mathcal M_m\) 同时承担两类互补角色。
+\begin{enumerate}
+  \item 它是固定尺度的完全主核：在两侧整数点恢复
+  \[
+  \mathcal M_m(-q)=S_q(m)\qquad(q\ge 1),
+  \qquad
+  \mathcal M_m(2g-2)=Z_m(\Sigma_g)\qquad(g\ge 1),
+  \]
+  并由直方图塔唯一恢复 Wedderburn 块谱、规范群规模、规范常数列以及全部偶 Bernoulli 数与偶值 \(\zeta(2r)\)；
+  \item 它又在渐近尺度上呈现严格二层分裂：全部广延 R\'enyi 热力学只剩单一斜率
+  \[
+  \lim_{m\to\infty}\frac1m H_q(\mu_m)=\log\varphi
+  \qquad(q>0),
+  \]
+  但 \(\log C_m\) 的次广延展开仍完整保存 even-\(\zeta\) 算术塔。
+\end{enumerate}
+因此，同一 Mellin--Dirichlet 主核在有限尺度上是碰撞矩、genus 振幅与半单块几何的共同母坐标，而在宏观极限上则严格分裂为“广延热力学平面”和“次广延算术校正层”两条正交结构层。
+\end{theorem}
+\begin{proof}
+双侧采样公式正是定理 \ref{thm:conclusion-foldbin-multiplicity-mellin-two-sided-unification}。直方图塔对 Wedderburn 分解、二维振幅、规范体积与 Bernoulli--\(\zeta\) 校正链的完备控制则由定理 \ref{thm:conclusion-foldbin-histogram-tower-arithmetic-topological-completeness} 给出。
+
+另一方面，广延 R\'enyi 熵率统一塌缩为 \(\log\varphi\)，而 even-\(\zeta\) 算术塔整体迁移到次广延规范校正层，正是定理 \ref{thm:conclusion-thermodynamic-flattening-subextensive-arithmetic-rigidity} 的内容。两部分并置，即得题述二层刚性。证毕。
+\end{proof}
+
+\begin{theorem}[算术 sharp 阈值与连续最小性之间的范畴性分裂]\label{thm:conclusion-arithmetic-sharp-threshold-vs-continuous-minimality-split}
+固定分辨率 \(m\)，记
+\[
+M_m:=\max_{x\in X_m}d_m(x),
+\qquad
+N:=|X_m|.
+\]
+则固定尺度审计存在两种本质不同且不可互换的极小完备性：
+\begin{enumerate}
+  \item 若目标是在全部支撑于 \(\{1,\dots,M_m\}\) 的整数直方图上精确恢复连续容量曲线，则所需的幂和标量个数恰为
+  \[
+  M_m.
+  \]
+  更准确地说，
+  \[
+  \{S_1(m),\dots,S_{M_m}(m)\}
+  \]
+  唯一决定纤维直方图、尾计数与连续容量曲线，而任何只读取少于 \(M_m\) 个幂和的协议在最坏情形下都严格不足；
+  \item 若目标是在开单纯形
+  \[
+  U_N:=\{w_1>\cdots>w_N>0,\ \sum_i w_i=1\}
+  \]
+  上连续单射恢复有序权重谱，则 Bayes 最优 InfoNCE 标量的最小完备数目恰为
+  \[
+  N-1.
+  \]
+\end{enumerate}
+因此，固定尺度上同时存在
+\[
+\text{Newton--Prony 型算术 sharp 阈值 }M_m
+\qquad\text{与}\qquad
+\text{连续谱层析的最小维数 }N-1,
+\]
+它们分别属于离散整数直方图上的精确重构与连续单纯形上的稳定可分辨性，彼此不可相互替代。
+\end{theorem}
+\begin{proof}
+前 \(M_m\) 个整数矩唯一决定直方图与连续容量曲线、而前 \(M_m-1\) 个一般情形下严格不足，分别由定理 \ref{thm:conclusion-finite-moment-spectrum-strict-determinacy-truncation}、定理 \ref{thm:conclusion-finite-moment-truncation-sharp-threshold} 与推论 \ref{cor:conclusion-finite-moment-audit-needs-exactly-Mm-scalars} 给出。
+
+另一方面，完整 Bayes--InfoNCE 数值塔与有序权重谱彼此唯一决定，而少于 \(N-1\) 个 Bayes 最优标量无法在 \(U_N\) 上给出连续单射恢复，这正是定理 \ref{thm:conclusion-capacity-ordered-spectrum-infonce-equivalence} 的最小连续测量数结论。故两种极小性确属不同范畴中的完备对象。证毕。
+\end{proof}
+
+\begin{theorem}[奇窗口全反演与偶窗口一维奇偶盲模]\label{thm:conclusion-oddwindow-full-inversion-evenwindow-rankone-parity-blindmode}
+记
+\[
+M:=F_{m+2},
+\qquad
+d_m(\cdot)
+\]
+为余数多重度剖面，\(P_m\) 为对应的局部推前核。则局部动力学的可逆性存在一条精确的模 \(3\) 分岔：
+\begin{enumerate}
+  \item 若
+  \[
+  m\not\equiv 1\pmod 3
+  \qquad\Longleftrightarrow\qquad
+  F_{m+2}\ \text{为奇数},
+  \]
+  则 \(d_m(\cdot)\) 唯一决定一切有限坐标模式计数 \(A_{m,I}(r;v)\)，特别地唯一决定全部单坐标条件概率 \(p_k(r)\) 与整个局部推前核 \(P_m\)；
+  \item 若
+  \[
+  m\equiv 1\pmod 3,
+  \]
+  则局部不可逆性坍缩为一条严格的一维角色盲模。更准确地，对最简单坐标 \(k=1\) 有
+  \[
+  \ker(I+T_1)=\CC\cdot \chi_{M/2},
+  \qquad
+  \chi_{M/2}(r)=(-1)^r.
+  \]
+  并且任取线性泛函 \(\Lambda\) 满足
+  \[
+  \Lambda(\chi_{M/2})\neq 0,
+  \]
+  则一枚额外横截标量 \(\Lambda(b_{m,1})\) 已足以唯一补全 \(b_{m,1}\)、\(p_1\) 与第一坐标切片上的局部推前核。
+\end{enumerate}
+换言之，偶窗口中的局部不可逆缺陷既不是分布式的，也不是高秩的；它是一个秩一奇偶扭量。
+\end{theorem}
+\begin{proof}
+奇窗口上的全部有限坐标模式反演由定理 \ref{thm:conclusion-residue-local-statistics-complete-reconstruction} 给出；其与
+\[
+m\not\equiv 1\pmod 3
+\]
+的等价性由推论 \ref{cor:conclusion-residue-mod3-local-reversibility-phase-transition} 给出。
+
+当 \(m\equiv 1\pmod 3\) 时，推论 \ref{cor:conclusion-residue-even-window-universal-parity-blind-mode} 精确识别出唯一核角色
+\[
+\chi_{M/2}(r)=(-1)^r,
+\]
+而推论 \ref{cor:conclusion-residue-even-window-one-functional-repair} 又说明任一横截泛函都足以补全这条盲模。证毕。
+\end{proof}
+
+\begin{theorem}[谱零点稀薄并不逼近均匀性；第一坐标偏置继承全局共振]\label{thm:conclusion-zero-sparsity-nonuniformity-localbias-faithfulness}
+设
+\[
+p_m(r):=\frac{d_m(r)}{2^m},
+\qquad
+u_m(r):=\frac1{F_{m+2}},
+\]
+并记谱零点集合为 \(\mathcal Z_m\)。则存在如下严格分离：
+\begin{enumerate}
+  \item 沿满足 \(3\mid(m+2)\) 的子列，
+  \[
+  \frac{|\mathcal Z_m|}{F_{m+2}}\longrightarrow 0,
+  \]
+  然而同时
+  \[
+  \chi^2(p_m\Vert u_m)=F_{m+2}\,\mathsf{Col}_m-1\longrightarrow +\infty.
+  \]
+  因此，非零 Fourier 模的稀薄化并不逼近输出分布的均匀化；
+  \item 第一坐标偏置能量
+  \[
+  E_{m,1}:=\sum_r \nu_{m,1}(r)^2
+  \]
+  是全局均匀性的忠实局部探针，即
+  \[
+  E_{m,1}=0
+  \iff
+  d_m(r)\equiv \frac{2^m}{F_{m+2}}
+  \iff
+  \mathsf{Col}_m=\frac1{F_{m+2}};
+  \]
+  \item 更强地，
+  \[
+  \liminf_{m\to\infty}F_{m+2}E_{m,1}
+  \ge
+  \frac12\tan^2(\pi\varphi^{-2})\,C_\varphi^2>0,
+  \]
+  而这一正下界恰由与全局碰撞缺口相同的两条 bulk 共振频率
+  \[
+  k=F_m,
+  \qquad
+  k=F_{m+1}
+  \]
+  强制产生。
+\end{enumerate}
+故第一坐标偏置并非局部旁证，而是对全局碰撞非均匀性的谱忠实局部显影。
+\end{theorem}
+\begin{proof}
+第一条正是定理 \ref{thm:conclusion-zero-density-pearson-explosion-strict-separation}。第二条由定理 \ref{thm:conclusion-first-coordinate-bias-energy-spectral-faithfulness} 给出。第三条则由推论 \ref{cor:conclusion-first-coordinate-bias-and-global-gap-common-resonant-origin} 给出，其中第一坐标偏置与全局碰撞缺口由同一对 Fibonacci 共振频率共同锁定。证毕。
+\end{proof}
+
+\begin{theorem}[冻结并非单一统计现象，而是双位率相变]\label{thm:conclusion-freezing-dual-bitrate-phase-transition}
+定义
+\[
+r_{\mathrm{uni}}:=\log_2\frac{2}{\varphi},
+\qquad
+r_{\mathrm{frz}}:=\frac{\alpha_\ast}{\log 2}.
+\]
+则在同一逐纤维预言机模型下存在两条本质不同的临界位率轴：
+\begin{enumerate}
+  \item 若存在常数 \(\eta>0\) 使均匀微观输入满足
+  \[
+  \liminf_{m\to\infty}\mathrm{Succ}_m(B_m)\ge \eta,
+  \]
+  则必有
+  \[
+  \liminf_{m\to\infty}\frac{B_m}{m}\ge r_{\mathrm{uni}};
+  \]
+  \item 对任意固定 \(a>a_{\mathrm c}+1\) 与任意 \(\eta\in(0,1)\)，深冻结微观输入的最小位预算满足
+  \[
+  \lim_{m\to\infty}\frac{B_{m,a}^{\mathrm{micro}}(\eta)}{m}=r_{\mathrm{frz}}.
+  \]
+\end{enumerate}
+并且在深冻结区还成立精确仿射分裂
+\[
+h_\infty^{\mathrm{micro}}(a)=\alpha_\ast+g_\ast,
+\qquad
+h_\infty(a)=g_\ast,
+\qquad
+P_a-P_{a-1}=\alpha_\ast,
+\]
+从而
+\[
+h_\infty^{\mathrm{micro}}(a)-h_\infty(a)=P_a-P_{a-1}=\alpha_\ast,
+\qquad
+r_{\mathrm{frz}}=\frac{P_a-P_{a-1}}{\log 2}.
+\]
+故冻结并非只把 escort 统计压到一条线性枝上；它同时把逐纤维精确微观反演的位率门槛从 \(r_{\mathrm{uni}}\) 抬升到 \(r_{\mathrm{frz}}\)。在此意义下，冻结是一条真正的可逆性相变线，而不只是自由能线性化。
+\end{theorem}
+\begin{proof}
+双阈值分离正是定理 \ref{thm:conclusion-uniform-vs-frozen-micro-bitrate-separation} 的内容。宏观与微观冻结 min-entropy 的差恰为 \(\alpha_\ast\)，由推论 \ref{cor:conclusion-micro-vs-macro-freezing-minentropy-gap} 给出；冻结一次差分识别最大纤维指数，则由定理 \ref{thm:conclusion-frozen-first-difference-recovers-maxfiber-exponent} 与推论 \ref{cor:conclusion-frozen-first-difference-micro-bitrate-identity} 给出。再结合推论 \ref{cor:conclusion-frozen-branch-two-scalar-closure}，即得题述仿射分裂与位率恒等式。证毕。
+\end{proof}
+
+\begin{theorem}[有限负样本对比学习只是容量亏损的 Bernstein--Mellin 层析]\label{thm:conclusion-contrastive-learning-bernstein-mellin-capacity-defect-tomography}
+固定分辨率 \(m\)。记连续容量曲线与其亏损函数为
+\[
+\mathcal C_m^{\mathrm{cont}}(T):=\sum_{x\in X_m}\min(d_m(x),T),
+\qquad
+R_m(T):=2^m-\mathcal C_m^{\mathrm{cont}}(T).
+\]
+则对每个整数 \(K\ge 2\)，Bayes 最优有限负样本损失都具有精确核表示
+\[
+\mathcal L_{K,m}^{\star}
+=
+\int_0^\infty \Psi_{K,m}(T)\,R_m(T)\,\dd T,
+\]
+其中 \(\Psi_{K,m}\) 是显式非负多项式核。于是，对比学习的全部 fold 依赖并不直接作用于“样本”，而是完全集中在容量亏损曲线 \(R_m\) 上。
+
+更强地，大负样本极限给出二阶 jet 的精确物理解释：
+\[
+\lim_{K\to\infty}\bigl(\log K-\mathcal L_{K,m}^{\star}\bigr)=H(\mu_m)=m\log 2-\kappa_m,
+\]
+而二阶系数则精确读出逆多重度谱和
+\[
+2^m\sum_{x\in X_m}\frac1{d_m(x)}-6|X_m|+5.
+\]
+最终，完整有限负样本塔
+\[
+\mathscr L_m=(\mathcal L_{2,m}^{\star},\dots,\mathcal L_{N,m}^{\star}),
+\qquad N=|X_m|,
+\]
+与下列三类对象彼此唯一决定：
+\[
+\mathcal C_m^{\mathrm{cont}},
+\qquad
+(h_m(d))_{d\ge 1},
+\qquad
+A_m^{\mathrm{bin}}\cong \bigoplus_{d\ge 1}M_d(\CC)^{\oplus h_m(d)}.
+\]
+因此，固定分辨率的 Bayes 对比学习并非一套独立统计机制，而是对半单块几何所做的一族 Bernstein--Mellin 层析。
+\end{theorem}
+\begin{proof}
+容量亏损核表示正是定理 \ref{thm:conclusion-infonce-capacity-gap-kernel-representation}。大负样本截距的极限由推论 \ref{cor:conclusion-infonce-large-k-visible-entropy-complement} 给出，而二阶 jet 的显式反演由定理 \ref{thm:conclusion-infonce-second-jet-reciprocal-multiplicity} 给出。最后，完整有限负样本塔、连续容量曲线、直方图与 Wedderburn 型之间的统一封口正是定理 \ref{thm:conclusion-infonce-capacity-wedderburn-unified-closure}。故对比学习的全部固定尺度几何都经由容量亏损 \(R_m\) 完成 Bernstein--Mellin 层析。证毕。
+\end{proof}
+
+\begin{conjecture}[容量全息序列的冻结双标量闭包与双阈值严格开裂]\label{conj:conclusion-capacity-holography-sequence-frozen-pair-gap}
+记固定分辨率连续容量曲线序列为
+\[
+\bigl(\mathcal C_m^{\mathrm{cont}}\bigr)_{m\ge 1}.
+\]
+则应成立如下更强的全息闭包：
+\begin{enumerate}
+  \item 序列 \(\bigl(\mathcal C_m^{\mathrm{cont}}\bigr)_{m\ge 1}\) 在 \(m\to\infty\) 时不仅完备决定每个固定尺度上的直方图、Wedderburn 型、预言机容量与有限负样本塔，而且还应渐近决定冻结双标量
+  \[
+  (\alpha_\ast,g_\ast);
+  \]
+  \item 一旦 \((\alpha_\ast,g_\ast)\) 被容量全息序列恢复，则冻结枝
+  \[
+  P_a=a\alpha_\ast+g_\ast
+  \]
+  及其微观临界位率
+  \[
+  r_{\mathrm{frz}}=\frac{\alpha_\ast}{\log 2}
+  \]
+  随之被完全决定；并且在稳定类型空间中应有严格不等式
+  \[
+  \alpha_\ast>\log\frac{2}{\varphi},
+  \qquad\text{等价地}\qquad
+  r_{\mathrm{frz}}>r_{\mathrm{uni}}.
+  \]
+\end{enumerate}
+换言之，容量全息序列若被推到极限，不仅决定有限尺度的 semisimple/oracle/contrastive 几何，而且还应强制出现均匀微观律与冻结微观律之间不可消去的严格位率间隙。
+\end{conjecture}
+\begin{proof}[论据]
+有限分辨率层面，定理 \ref{thm:conclusion-infonce-capacity-wedderburn-unified-closure} 已表明完整有限负样本塔、连续容量曲线、纤维直方图与 Wedderburn 型彼此互逆；冻结层面，推论 \ref{cor:conclusion-frozen-branch-two-scalar-closure} 又说明任取两点冻结值即可线性恢复 \((\alpha_\ast,g_\ast)\)。这说明“固定尺度容量全息”与“冻结双标量闭包”之间只差一道极限函子。
+
+另一方面，推论 \ref{cor:conclusion-uniform-frozen-micro-bitrate-gap-formula} 已经把
+\[
+r_{\mathrm{frz}}-r_{\mathrm{uni}}
+=
+\frac{\alpha_\ast-\log(2/\varphi)}{\log 2}
+\]
+压缩成单个指数差。若稳定类型空间中 \(\alpha_\ast>\log(2/\varphi)\) 的严格开裂成立，则容量全息序列在极限上恢复 \((\alpha_\ast,g_\ast)\) 之后，便会自动强制双阈值严格分离。证毕。
+\end{proof}
+
+\paragraph{统一读法}
+这条新链可压缩为
+\[
+\text{continuous capacity holography}
+\Longrightarrow
+\text{Mellin--Dirichlet master kernel}
+\Longrightarrow
+\text{rank-one parity blind mode}
+\Longrightarrow
+\text{dual bitrate freezing transition}
+\Longrightarrow
+\text{contrastive Bernstein--Mellin tomography}.
+\]
+其终态判断是：连续容量曲线并不是若干预算函数的事后汇编，而是固定分辨率上主序、InfoNCE、Wedderburn 型与有限负样本塔的共同母坐标；Mellin--Dirichlet 主核则把碰撞矩、genus 振幅与 even-\(\zeta\) 算术层统一进同一有限 Dirichlet 多项式。另一方面，局部动力学的全部偶窗口不可逆性又被严格压缩到一条秩一奇偶盲模，而冻结枝则把统计冻结升级为真正的双位率相变。于是，在本文当前框架中，容量全息、局部奇偶障碍、冻结双阈值与对比学习层析已经不再是平行语言，而是同一条 semisimple/oracle/escort 几何的四个互补侧面。
+
+\endinput

--- a/theory/2026_golden_ratio_driven_scan_projection_generation_recursive_emergence/sections/body/conclusion/subsec__conclusion-chain-markov-loop-memory-rigidity.tex
+++ b/theory/2026_golden_ratio_driven_scan_projection_generation_recursive_emergence/sections/body/conclusion/subsec__conclusion-chain-markov-loop-memory-rigidity.tex
@@ -245,6 +245,8 @@ a_\Delta^4\sim \Delta^4e^{-2\Delta},
 证毕。
 \end{proof}
 
+\input{thm__conclusion-tree-detentropy-cmi-quartic-visibility}
+
 \input{thm__conclusion-chowliu-cutbudget-cyclelattice-doublescale}
 
 \input{thm__conclusion-scalekernel-tree-fourthorder-dichotomy}

--- a/theory/2026_golden_ratio_driven_scan_projection_generation_recursive_emergence/sections/body/conclusion/subsec__conclusion-coordinatebundle-integrable-poisson-gumbel-resistance-shapley.tex
+++ b/theory/2026_golden_ratio_driven_scan_projection_generation_recursive_emergence/sections/body/conclusion/subsec__conclusion-coordinatebundle-integrable-poisson-gumbel-resistance-shapley.tex
@@ -1,0 +1,385 @@
+\subsection{内部坐标束屏幕的原子可积性、Poisson--Gumbel 临界窗与电阻--Shapley 同一}\label{subsec:conclusion-coordinatebundle-integrable-poisson-gumbel-resistance-shapley}
+
+沿用小节 \ref{subsec:conclusion-screen-hypercube-boundary-torsor-shapley}、
+小节 \ref{subsec:conclusion-coordinatebundle-kirchhoff-poissonbinomial-logscale} 与
+小节 \ref{subsec:conclusion-coordinatebundle-codimension-tree-star-kirchhoff-rigidity}
+的记号。固定非空
+\[
+J\subseteq [n],
+\qquad
+s:=|J|,
+\qquad
+L_J:=2^{m(n-s)},
+\qquad
+S_J^{\mathrm{int}}\subseteq E(\Gamma),
+\]
+并记
+\[
+\mathcal D_{m,n}:=\{2^{m\ell}:0\le \ell\le n\}.
+\]
+对每个
+\[
+a_{J^c}\in\{0,\dots,2^m-1\}^{J^c},
+\]
+记对应板层为 \(\Sigma_{a_{J^c}}\)，其外边界面集为
+\[
+E_{a_{J^c}}:=\partial_{\mathrm{out}}\Sigma_{a_{J^c}},
+\qquad
+d_{m,s}:=|E_{a_{J^c}}|=2s\,2^{m(s-1)}.
+\]
+前述三条链已经分别固定了：后验纤维的仿射超立方体结构、外边界精确化的逐板层完全因子化、随机外边界审计的 Poisson--binomial 残余律、面级 Shapley--Banzhaf 原子律，以及严格边界价差下的纯外边界星树最优性。把这些接口并置之后，内部坐标束屏幕还可进一步压缩成一条更强的可积主线：原始隐藏复杂度在唯一无交互的对数标度下退化为纯 \(m\)-比特坐标原子；均匀外边界审计具有精确的 Poisson--Gumbel 临界窗；同层 Gibbs 边占用、有效电阻与 Shapley 价值在无权情形下严格重合；而严格边界价差又把零温最优补全压缩为纯星子族，并给出每个隐藏原子的显式熵密度。
+
+\begin{theorem}[隐藏复杂度的原子可积化与对数标度唯一性]\label{thm:conclusion-coordinatebundle-atomic-integrability-logscale}
+定义隐藏体积
+\[
+\Delta_m(J):=L_J=2^{m(n-s)}.
+\]
+则下列四类复杂度在内部坐标束屏幕上完全锁定于同一原始尺度，其中 Kolmogorov 项只差 \(O(1)\)：
+\[
+H(X\mid Y_J),
+\qquad
+\min\{\text{exact audit bits}\},
+\qquad
+\min\{\text{linear completion dimension}\},
+\qquad
+\max_{y}\max_{x:T_Jx=y}K(x\mid y,m,n,J).
+\]
+更精确地，前三者都恰等于
+\[
+L_J,
+\]
+而第四者满足
+\[
+\max_{y}\max_{x:T_Jx=y}K(x\mid y,m,n,J)=L_J+O(1).
+\]
+
+进一步，对任意函数 \(\phi:\mathcal D_{m,n}\to\RR\)，定义
+\[
+h_\phi(J):=\phi(\Delta_m(J)).
+\]
+则“所有二阶及以上 Möbius 原子同时消失”当且仅当存在常数 \(A_0,C\in\RR\) 使
+\[
+\phi(t)=A_0+C\log_2 t
+\qquad
+(t\in \mathcal D_{m,n}).
+\]
+因此一切无交互重标都只能写成
+\[
+h_\phi(J)=A_0+Cm(n-s),
+\]
+并对任意 \(j\notin J\) 满足
+\[
+h_\phi(J)-h_\phi(J\cup\{j\})=Cm.
+\]
+特别地，在自然规一化 \(h_{\log}(J):=\log_2\Delta_m(J)\) 下，隐藏复杂度严格分裂为 \(n-s\) 个彼此独立的 \(m\)-比特坐标原子。
+\end{theorem}
+\begin{proof}
+由定理 \ref{thm:conclusion-coordinate-bundle-fourfold-complexity-collapse}，
+\[
+H(X\mid Y_J)=L_J,
+\qquad
+\min\{\text{exact audit bits}\}=L_J,
+\qquad
+\min\{\text{linear completion dimension}\}=L_J,
+\]
+并且
+\[
+\max_{y}\max_{x:T_Jx=y}K(x\mid y,m,n,J)=L_J+O(1).
+\]
+这就给出原始尺度上的四重一致坍缩。
+
+另一方面，定理 \ref{thm:conclusion-coordinate-bundle-logscale-unique-nointeraction} 已证明：对
+\[
+h_\phi(J)=\phi(\Delta_m(J)),
+\]
+其全部二阶及以上 Möbius 系数同时为零，当且仅当 \(\phi\) 在 \(\mathcal D_{m,n}\) 上是 \(\log_2 t\) 的仿射函数。于是
+\[
+h_\phi(J)=A_0+C\log_2\Delta_m(J)=A_0+Cm(n-s),
+\]
+故对每个 \(j\notin J\) 都有
+\[
+h_\phi(J)-h_\phi(J\cup\{j\})=Cm.
+\]
+取 \(C=1\) 即得自然的 \(\log_2\) 标度下的 \(m\)-比特原子分裂。证毕。
+\end{proof}
+
+\begin{theorem}[均匀外边界审计的 Poisson--Gumbel 临界窗]\label{thm:conclusion-coordinatebundle-poisson-gumbel-critical-window}
+设每张外边界面独立地以相同概率 \(p\in[0,1]\) 被纳入审计集 \(B\)。记随机残余歧义秩为
+\[
+\Lambda_J(B):=\rank_{\ZZ}\ker f_{S_J^{\mathrm{int}}\cup B}.
+\]
+则
+\[
+\Lambda_J(B)\sim \mathrm{Bin}\!\bigl(L_J,q_{m,s}(p)\bigr),
+\qquad
+q_{m,s}(p):=(1-p)^{d_{m,s}}.
+\]
+从而 exactification 概率具有闭式
+\[
+\mathbb P\bigl(\Lambda_J(B)=0\bigr)=\bigl(1-q_{m,s}(p)\bigr)^{L_J}.
+\]
+
+对任意 \(c\in\RR\)，定义临界窗
+\[
+p_{m,s}(c):=1-\exp\!\left(-\frac{\log L_J+c}{d_{m,s}}\right).
+\]
+则有精确恒等式
+\[
+q_{m,s}\bigl(p_{m,s}(c)\bigr)=\frac{e^{-c}}{L_J},
+\]
+并且
+\[
+\Lambda_J(B)\ \Longrightarrow\ \mathrm{Poisson}(e^{-c}),
+\qquad
+\mathbb P\bigl(\Lambda_J(B)=0\bigr)\longrightarrow e^{-e^{-c}}.
+\]
+因此，内部坐标束屏幕的随机 exactification 具有一条 sharp 的 Poisson--Gumbel 临界窗，其极限分布完全由独立板层漏检的几何决定。
+\end{theorem}
+\begin{proof}
+由定理 \ref{thm:conclusion-coordinate-bundle-random-audit-poisson-binomial}，\(\Lambda_J(B)\) 是各板层未命中事件之和。对均匀审计概率 \(p\)，每条板层的漏检概率都相同，且
+\[
+q_{m,s}(p)=\prod_{e\in E_{a_{J^c}}}(1-p)=(1-p)^{d_{m,s}}.
+\]
+板层总数为 \(L_J\)，故
+\[
+\Lambda_J(B)\sim \mathrm{Bin}\!\bigl(L_J,q_{m,s}(p)\bigr),
+\]
+并且
+\[
+\mathbb P\bigl(\Lambda_J(B)=0\bigr)=\bigl(1-q_{m,s}(p)\bigr)^{L_J}.
+\]
+
+若取
+\[
+p=p_{m,s}(c)=1-\exp\!\left(-\frac{\log L_J+c}{d_{m,s}}\right),
+\]
+则
+\[
+q_{m,s}(p)=\exp(-\log L_J-c)=\frac{e^{-c}}{L_J}.
+\]
+于是
+\[
+L_J q_{m,s}(p)\to e^{-c},
+\qquad
+q_{m,s}(p)\to 0.
+\]
+由经典二项分布 Poisson 极限定理，
+\[
+\Lambda_J(B)\Rightarrow \mathrm{Poisson}(e^{-c}).
+\]
+再对零点概率取极限便得到
+\[
+\mathbb P\bigl(\Lambda_J(B)=0\bigr)
+\;=\;
+\left(1-\frac{e^{-c}}{L_J}\right)^{L_J}
+\longrightarrow
+e^{-e^{-c}}.
+\]
+证毕。
+\end{proof}
+
+\begin{corollary}[临界审计密度的封闭式与 sharp 阈值]\label{cor:conclusion-coordinatebundle-critical-audit-density}
+在定理 \ref{thm:conclusion-coordinatebundle-poisson-gumbel-critical-window} 的设定下，定义
+\[
+p_{m,s}^{\mathrm{crit}}:=p_{m,s}(0)=1-\exp\!\left(-\frac{\log L_J}{d_{m,s}}\right).
+\]
+则 exactification 的 sharp 阈值由单一无量纲参数
+\[
+\frac{\log L_J}{d_{m,s}}
+=
+\frac{m(n-s)\log 2}{2s\,2^{m(s-1)}}
+\]
+控制。更精确地：
+\begin{enumerate}
+  \item 若
+  \[
+  L_J(1-p)^{d_{m,s}}\to 0,
+  \]
+  则
+  \[
+  \mathbb P\bigl(\Lambda_J(B)=0\bigr)\to 1;
+  \]
+  \item 若
+  \[
+  L_J(1-p)^{d_{m,s}}\to\infty,
+  \]
+  则
+  \[
+  \mathbb P\bigl(\Lambda_J(B)=0\bigr)\to 0.
+  \]
+\end{enumerate}
+此外，在
+\[
+\frac{\log L_J}{d_{m,s}}\to 0
+\]
+的 regime 中，成立 sharp 渐近
+\[
+p_{m,s}^{\mathrm{crit}}
+\sim
+\frac{\log L_J}{d_{m,s}}
+=
+\frac{m(n-s)\log 2}{2s\,2^{m(s-1)}}.
+\]
+特别地，对固定 \(s\ge 2\) 且 \(m\to\infty\)，临界审计密度按上式指数下沉。
+\end{corollary}
+\begin{proof}
+第一条闭式来自
+\[
+L_J=2^{m(n-s)},
+\qquad
+d_{m,s}=2s\,2^{m(s-1)}.
+\]
+再由定理 \ref{thm:conclusion-coordinatebundle-poisson-gumbel-critical-window}，
+\[
+\mathbb P\bigl(\Lambda_J(B)=0\bigr)
+=
+\bigl(1-(1-p)^{d_{m,s}}\bigr)^{L_J}.
+\]
+若 \(L_J(1-p)^{d_{m,s}}\to 0\)，则右端趋于 \(1\)；若该量趋于 \(+\infty\)，则右端趋于 \(0\)。这就给出 sharp 阈值的充要尺度。
+
+最后，当 \(\log L_J/d_{m,s}\to 0\) 时，
+\[
+1-e^{-x}\sim x
+\qquad
+(x\downarrow 0),
+\]
+故
+\[
+p_{m,s}^{\mathrm{crit}}
+=
+1-\exp\!\left(-\frac{\log L_J}{d_{m,s}}\right)
+\sim
+\frac{\log L_J}{d_{m,s}}.
+\]
+将 \(L_J\) 与 \(d_{m,s}\) 的闭式代入即可。证毕。
+\end{proof}
+
+\begin{theorem}[同层 Gibbs 占用、有效电阻与 Shapley 原子的严格同一]\label{thm:conclusion-coordinatebundle-resistance-shapley-identity}
+固定一条板层 \(E_{a_{J^c}}\)。在极小精确化 Gibbs 系综
+\[
+\mu_{J,\mathbf x}(B)\propto \prod_{e\in B}x_e
+\]
+下，对任意 \(e\in E_{a_{J^c}}\) 都有
+\[
+\mu_{J,\mathbf x}(e\in B)
+=
+\frac{x_e}{\sum_{f\in E_{a_{J^c}}}x_f}
+=
+x_e\,
+R^{\mathrm{eff}}_{Q_{S_J^{\mathrm{int}}},\mathbf x}(\infty,a_{J^c}),
+\]
+其中
+\[
+R^{\mathrm{eff}}_{Q_{S_J^{\mathrm{int}}},\mathbf x}(\infty,a_{J^c})
+=
+\left(\sum_{f\in E_{a_{J^c}}}x_f\right)^{-1}.
+\]
+
+若进一步取无权情形 \(x_e\equiv 1\)，则对任意 \(e\in E_{a_{J^c}}\) 都有严格三重同一性
+\[
+\mu_{J,\mathbf 1}(e\in B)
+=
+R^{\mathrm{eff}}_{Q_{S_J^{\mathrm{int}}},\mathbf 1}(\infty,a_{J^c})
+=
+\operatorname{Sh}_e(g_J)
+=
+\frac{1}{|E_{a_{J^c}}|}.
+\]
+并且未归一化 Banzhaf 值满足
+\[
+\beta_e(g_J)=2^{1-|E_{a_{J^c}}|}.
+\]
+因此，同一板层上的物理边占用概率、电网络有效电阻与合作博弈中的 Shapley 原子在无权情形下并非仅仅同尺度，而是同一个数值对象。
+\end{theorem}
+\begin{proof}
+由推论 \ref{cor:conclusion-coordinate-bundle-gibbs-resistance-closed-form}，
+\[
+\mu_{J,\mathbf x}(e\in B)=\frac{x_e}{\sum_{f\in E_{a_{J^c}}}x_f},
+\qquad
+R^{\mathrm{eff}}_{Q_{S_J^{\mathrm{int}}},\mathbf x}(\infty,a_{J^c})
+=
+\left(\sum_{f\in E_{a_{J^c}}}x_f\right)^{-1}.
+\]
+两式相乘即得加权恒等式。
+
+在无权情形 \(x_e\equiv 1\) 下，
+\[
+\mu_{J,\mathbf 1}(e\in B)
+=
+R^{\mathrm{eff}}_{Q_{S_J^{\mathrm{int}}},\mathbf 1}(\infty,a_{J^c})
+=
+\frac{1}{|E_{a_{J^c}}|}.
+\]
+另一方面，推论 \ref{cor:conclusion-coordinate-bundle-face-shapley-banzhaf} 已给出
+\[
+\operatorname{Sh}_e(g_J)=\frac{1}{|E_{a_{J^c}}|},
+\qquad
+\beta_e(g_J)=2^{1-|E_{a_{J^c}}|}.
+\]
+故三重同一与 Banzhaf 公式同时成立。证毕。
+\end{proof}
+
+\begin{theorem}[严格边界价差下的纯星零温塌缩与熵密度]\label{thm:conclusion-coordinatebundle-pure-star-zero-temperature-entropy}
+设 \(J\neq \varnothing\)，并在压缩图 \(\mathcal G_J=Q_{S_J^{\mathrm{int}}}\) 上赋边权。若满足严格价差
+\[
+\max\{w_e:\ e\ \text{incident to }\infty\}
+<
+\min\{w_e:\ e\ \text{not incident to }\infty\},
+\]
+则每一棵最小生成树都纯由外边界边组成；等价地，所有零温成本最优的极小精确化都属于纯外边界星树子族 \(\mathfrak E_J^{\min}\)。
+
+若进一步取与上述 strict-gap 相容的对称特化，即所有外边界边同权且严格低于所有内部跨分量边，则零温最优族恰等于 \(\mathfrak E_J^{\min}\)，并且其精确基数为
+\[
+|\mathfrak E_J^{\min}|
+=
+\bigl(2s\,2^{m(s-1)}\bigr)^{L_J}
+=
+\bigl(2s\,2^{m(s-1)}\bigr)^{2^{m(n-s)}}.
+\]
+因此每个隐藏原子的零温熵密度恰为
+\[
+\frac{1}{L_J}\log |\mathfrak E_J^{\min}|
+=
+\log(2s)+m(s-1)\log 2.
+\]
+于是，一旦边界价差跨过 strict gap，内部坐标束屏幕的零温几何便塌缩为“每层各取一边”的纯星热力学，而其残余熵密度可由单层外边界的基数显式读出。
+\end{theorem}
+\begin{proof}
+定理 \ref{thm:conclusion-coordinatebundle-strict-boundary-gap-forces-stars} 已证明：在 strict-gap 假设下，\(\mathcal G_J\) 的每一棵最小生成树都只能纯由 incident to \(\infty\) 的外边界边组成。由定理 \ref{thm:conclusion-coordinatebundle-all-minimal-exactifications-spanning-trees}，这等价于所有零温成本最优极小精确化都落在 \(\mathfrak E_J^{\min}\) 中。
+
+在进一步的对称特化中，每层所有外边界边都同时达到同一最小代价，而所有内部跨分量边都被 strict gap 排除，故零温最优族恰好就是 \(\mathfrak E_J^{\min}\) 本身。再由推论 \ref{cor:conclusion-coordinatebundle-pure-boundary-star-family-count}，
+\[
+|\mathfrak E_J^{\min}|
+=
+\bigl(2s\,2^{m(s-1)}\bigr)^{L_J}.
+\]
+两边取对数并除以
+\[
+L_J=2^{m(n-s)}
+\]
+即得
+\[
+\frac{1}{L_J}\log |\mathfrak E_J^{\min}|
+=
+\log(2s)+m(s-1)\log 2.
+\]
+证毕。
+\end{proof}
+
+\begin{conjecture}[完全可积屏幕的坐标束刻画]\label{conj:conclusion-coordinatebundle-complete-integrability-characterization}
+设 \(S\) 是某个固定 dyadic 复形上的部分屏幕，并同时满足：
+\begin{enumerate}
+  \item 对每个综合征 \(y\)，后验纤维 \(X\mid (Y_S=y)\) 都是仿射超立方体，且自由坐标相互独立；
+  \item 在均匀外边界审计下，残余秩服从一条 sharp 的 Poisson--Gumbel 临界窗；
+  \item 在无权零温极限中，同层 Gibbs 边占用概率、有效电阻与 Shapley 价值严格重合；
+  \item 隐藏体积函数存在且仅存在一个能够消去全部高阶 Möbius 原子的标度。
+\end{enumerate}
+则在坐标重标与显然的可见等价之下，\(S\) 应当必为某个内部坐标束屏幕 \(S_J^{\mathrm{int}}\)。
+
+这一猜想把猜想 \ref{conj:conclusion-coordinate-bundle-complete-factorization-rigidity} 的三条弱判据提升为概率、博弈、电网络与热力学的联合刚性：一旦后验超立方体、exactification 可乘性与 Möbius 单层支撑继续强化为 Poisson--Gumbel 窗口、对数唯一无交互标度与电阻--Shapley 同一，内部坐标束屏幕应当成为当前部分屏幕理论中唯一的完全可积分支。
+\end{conjecture}
+
+\noindent
+因此，内部坐标束屏幕的隐藏几何可被进一步压成一条统一的可积链：原始尺度上的 Shannon 熵、exact audit 位数、线性补全维数与条件 Kolmogorov 容量都锁定在同一整数 \(L_J\) 上；而一旦切换到唯一无交互的对数标度，全部隐藏复杂度又严格分裂为 \(n-s\) 个 \(m\)-比特坐标原子。与此同时，均匀外边界审计的残余秩不只是一条 Poisson--binomial 和，还在临界窗内呈现出精确的 Poisson--Gumbel 截断；单层 Gibbs 边占用、电阻与 Shapley 值则在无权极限下三重合一，Banzhaf 指数只是同层基数的指数影子。最后，strict gap 把全部零温最优补全压缩为纯星子族，并留下每个隐藏原子都可显式读取的线性熵密度。由此，内部坐标束屏幕不再只是一般屏幕理论中的一个可解例子，而成为一个在后验几何、随机审计、合作博弈与电网络四个接口上同时闭合的完全可积对象。
+
+\endinput

--- a/theory/2026_golden_ratio_driven_scan_projection_generation_recursive_emergence/sections/body/conclusion/subsec__conclusion-dualinterface-2d-toeplitz-prony-discriminant-badreduction.tex
+++ b/theory/2026_golden_ratio_driven_scan_projection_generation_recursive_emergence/sections/body/conclusion/subsec__conclusion-dualinterface-2d-toeplitz-prony-discriminant-badreduction.tex
@@ -1,0 +1,283 @@
+\subsection{双接口 \texorpdfstring{$2D$}{2D} 审计律、Toeplitz 非忠实性与判别式坏约化统一}\label{subsec:conclusion-dualinterface-2d-toeplitz-prony-discriminant-badreduction}
+沿用定义 \ref{def:pom-hankel-normal-form}、定理 \ref{thm:dephys-hankel-finite-audit}、推论 \ref{cor:xi-hankel-2d-sharpness}、定理 \ref{thm:conclusion-visible-joint-horizon-sharp-2d}、定理 \ref{thm:xi-prony-moment-map-jacobian-delta4}、定理 \ref{thm:xi-toeplitz-metric-spectrum-normal-form}、推论 \ref{cor:xi-negative-spectrum-product-dethankel-square}、定理 \ref{thm:xi-dethankel-vandermonde-square-finite-blaschke}、定理 \ref{thm:xi-hankel-spike-singular-spectrum-separation}、定理 \ref{thm:pom-stiff0-hankel-good-reduction-dim-stability}、定理 \ref{thm:xi-hankel-finitefield-random-completion-nondegenerate} 与定理 \ref{thm:xi-gramshift-bad-primes-weight-discriminant} 的记号。前文已分别在碰撞矩一侧建立了 Hankel 最小实现的 \(2d\) 点锁定，在扫描--Toeplitz 一侧建立了 \(2D\) 视界的 sharp 门槛，并在 Prony Jacobian、Hankel 行列式、负谱乘积与坏素机制之间写出了若干局部闭式。将这些先前分散的接口重新拼接后，可以得到一条此前尚未在结论区单列的刚性链：同一最小 realization 维数 \(D\) 同时支配碰撞接口与扫描接口的最短审计窗；同一 strictification 轨道解释整个 Toeplitz 审计宇宙的非忠实性；同一 Vandermonde--判别式对象既度量微分可逆性，也度量负谱体积与 \(p\)-进坏约化。
+
+\begin{theorem}[双接口的普适 \texorpdfstring{$2D$}{2D} 审计律]\label{thm:conclusion-dualinterface-universal-2d-audit-law}
+设同一机制同时给出两类有限型接口：
+\[
+a_n:=S_q(n+2)\qquad(n\ge 0),
+\]
+其 Hankel 秩为 \(D\)；以及扫描谱指纹
+\[
+u_n=\sum_{j=1}^{D}c_j r_j^n,
+\]
+其中 \((r_j,c_j)\) 处于一般位置。则下列三事同时成立：
+\begin{enumerate}
+  \item 在碰撞接口的最小偏移证书 \(\ell_q\) 处，长度恰为 \(2D\) 的连续窗口
+  \[
+  (a_{\ell_q},a_{\ell_q+1},\dots,a_{\ell_q+2D-1})
+  \]
+  唯一锁定全部碰撞动力学，亦即唯一确定 \(\mathrm{HANKELNF}_q\)、递推、特征多项式与 Perron 根。
+  \item 在扫描接口上，长度恰为 \(2D\) 的连续前缀
+  \[
+  (u_0,u_1,\dots,u_{2D-1})
+  \]
+  唯一锁定全部谱原子与 Toeplitz--PSD 语义。
+  \item 长度不超过 \(2D-1\) 的连续样本在两侧都严格不足：碰撞侧仍保留一维 Hankel 纤维，扫描侧仍存在一般位置下的非唯一性见证。
+\end{enumerate}
+因此，\(2D\) 不是某一单侧接口的偶然门槛，而是同一最小 realization 在“代数最小实现”和“谱最小实现”两侧共同服从的 sharp 信息律。
+\end{theorem}
+
+\begin{proof}
+碰撞侧由定理 \ref{thm:dephys-hankel-finite-audit} 直接给出：当 Hankel 秩为 \(D\) 时，最小偏移证书 \(\ell_q\) 处的长度 \(2D\) 连续窗口唯一确定 \(\mathrm{HANKELNF}_q\)，因而唯一决定整条碰撞序列及其全部后续指纹。其 sharp 性则由推论 \ref{cor:xi-hankel-2d-sharpness} 给出：任何长度 \(2D-1\) 的连续窗口在一般位置上都仍保留一维自由度，不能唯一恢复全序列。
+
+扫描侧由定理 \ref{thm:conclusion-visible-joint-horizon-sharp-2d} 给出：长度 \(2D\) 的样本前缀既足以完成谱原子唯一恢复，也足以完成 Toeplitz--PSD 的全阶语义判定；而任何长度不超过 \(2D-1\) 的前缀都存在非唯一性见证。于是同一 sharp 阈值在碰撞接口与扫描接口同时成立。证毕。
+\end{proof}
+
+\begin{theorem}[Toeplitz--扫描审计函子的非忠实性]\label{thm:conclusion-toeplitz-scan-audit-functor-nonfaithful}
+记 \(\mathscr C\) 为 Carath\'eodory 接口范畴，并对每个对象 \(C\) 赋予核
+\[
+K_C(w,w'):=\frac{C(w)+C(w')^\ast}{1-ww'^\ast}.
+\]
+再记 \(\mathscr O\) 为由 \(K_C\) 及其函子性后代生成的审计对象范畴，包括全部 Toeplitz 截断、相应谱铅笔以及由扫描指纹编译出的负向量见证。则自然审计函子
+\[
+\mathcal F:\mathscr C\longrightarrow \mathscr O
+\]
+不忠实；更精确地，对任意 \(\eta\in\RR\) 都有
+\[
+\mathcal F(C+i\eta)=\mathcal F(C).
+\]
+因此 \(\mathcal F\) 必经 strictification 轨道商 \(\mathscr C/(i\RR)\) 因子化。换言之，若不引入外置寄存轴，则任何仅在 \(\mathscr O\) 内进行的协议都不可能忠实恢复 \(C\) 的全信息。
+\end{theorem}
+
+\begin{proof}
+定理 \ref{thm:conclusion-toeplitz-gauge-blindness-zero-dimensional-ledger-necessity} 已证明：对任意 \(\eta\in\RR\)，strictification
+\[
+C\longmapsto C^\sharp:=C+i\eta
+\]
+不改变核 \(K_C\)，故不改变任何由 \(K_C\) 生成的 Toeplitz 截断、谱读出与 PSD 证书。另一方面，由扫描指纹编译出的负向量见证本身也是从这些 Toeplitz 数据函子性构造出来的，因此同样在 \(C\mapsto C+i\eta\) 下不变。于是 \(\mathscr O\) 中所有可见对象都只能依赖于 \(C\) 的 strictification 轨道，而不能区分同一轨道内的不同代表，故 \(\mathcal F\) 不忠实，并必经商范畴 \(\mathscr C/(i\RR)\) 因子化。证毕。
+\end{proof}
+
+\begin{theorem}[Prony 雅可比体积与负谱体积势的精确同一]\label{thm:conclusion-prony-jacobian-negative-spectrum-volume-identity}
+设扫描谱指纹具有有限原子分解
+\[
+u_n=4\pi\sum_{j=1}^{\kappa} w_j z_j^n,
+\qquad
+w_j>0,\quad z_j\in\mathbb D,\quad z_i\neq z_j\ (i\neq j).
+\]
+令 \(\lambda_1^-,\dots,\lambda_\kappa^-\) 为相应 Toeplitz 审计度量下的负广义特征值，并令
+\[
+\Phi_\kappa:(\omega_1,\dots,\omega_\kappa,z_1,\dots,z_\kappa)\longmapsto (u_0,\dots,u_{2\kappa-1}),
+\qquad
+\omega_j:=4\pi w_j,
+\]
+为 Prony 矩映射。则有严格恒等式
+\[
+\prod_{i=1}^{\kappa}|\lambda_i^-|
+=(4\pi)^\kappa\Bigl(\prod_{j=1}^{\kappa}w_j\Bigr)\cdot \bigl|\det D\Phi_\kappa\bigr|.
+\]
+亦即，局部可逆性的 Jacobian 体积元与负谱体积势完全同一，仅差一个显式正权因子。
+\end{theorem}
+
+\begin{proof}
+由定理 \ref{thm:xi-prony-moment-map-jacobian-delta4}，在 \(\omega_j=4\pi w_j\) 的记号下，
+\[
+\bigl|\det D\Phi_\kappa\bigr|
+=(4\pi)^\kappa
+\Bigl(\prod_{j=1}^{\kappa}w_j\Bigr)
+\Bigl(\prod_{1\le i<j\le \kappa}|z_j-z_i|^4\Bigr).
+\]
+另一方面，由定理 \ref{thm:xi-dethankel-vandermonde-square-finite-blaschke} 与推论 \ref{cor:xi-negative-spectrum-product-dethankel-square}，
+\[
+\prod_{i=1}^{\kappa}|\lambda_i^-|
+=(4\pi)^{2\kappa}
+\Bigl(\prod_{j=1}^{\kappa}w_j^2\Bigr)
+\Bigl(\prod_{1\le i<j\le \kappa}|z_j-z_i|^4\Bigr).
+\]
+将后一式除以前一式即可得到所述恒等式。证毕。
+\end{proof}
+
+\begin{corollary}[节点并合的四次判别指数律]\label{cor:conclusion-node-coalescence-quartic-discriminant-law}
+沿用定理 \ref{thm:conclusion-prony-jacobian-negative-spectrum-volume-identity} 的设定。设一族参数 \(t\mapsto (w_j(t),z_j(t))\) 光滑变化，并存在一个聚簇 \(I\subset\{1,\dots,\kappa\}\)，满足对所有 \(i,j\in I\),
+\[
+z_i(t)-z_j(t)=O(\varepsilon(t)),
+\qquad
+\varepsilon(t)\to 0,
+\]
+而簇外节点差与全部权重保持远离零。则在一般横截条件下，
+\[
+\bigl|\det D\Phi_\kappa(t)\bigr|
+\asymp
+|\varepsilon(t)|^{\,4\binom{|I|}{2}},
+\qquad
+\prod_{m=1}^{\kappa}|\lambda_m^-(t)|
+\asymp
+|\varepsilon(t)|^{\,4\binom{|I|}{2}}.
+\]
+特别地，单对节点并合时，临界指数恰为 \(4\)。
+\end{corollary}
+
+\begin{proof}
+定理 \ref{thm:conclusion-prony-jacobian-negative-spectrum-volume-identity} 两侧都含有同一 Vandermonde 四次因子
+\[
+\prod_{1\le i<j\le \kappa}|z_j-z_i|^4.
+\]
+在簇外差值与权重都保持非退化时，全部会消失的因子都只来自簇内成对差值，因此退化阶精确为
+\[
+4\cdot \#\{(i,j):i<j,\ i,j\in I\}
+=
+4\binom{|I|}{2}.
+\]
+于是两侧都具有同一临界指数。证毕。
+\end{proof}
+
+\begin{theorem}[熵缺口趋零时负子空间的秩一塌缩]\label{thm:conclusion-entropy-gap-rankone-negative-collapse}
+在 Toeplitz--扫描 Hankel 同构分解
+\[
+R_N^\ast T_N(C)R_N=
+\begin{pmatrix}
+P_N & 0\\
+0 & -\,\mathsf H_{\kappa-1}^\ast\mathsf H_{\kappa-1}
+\end{pmatrix}
+\]
+的稳定区间内，设
+\[
+g:=\kappa_{\mathrm{ind}}-S_{\mathrm{def}}\downarrow 0,
+\qquad
+S_{\mathrm{def}}>0\ \text{固定}.
+\]
+则 Hankel 负块的奇异谱满足
+\[
+\sigma_1(\mathsf H_{\kappa-1})=4\pi S_{\mathrm{def}}+O(g),
+\qquad
+\sigma_j(\mathsf H_{\kappa-1})=O(g)\quad(2\le j\le \kappa).
+\]
+从而 Toeplitz 审计度量下的负广义特征值满足
+\[
+\lambda_1^-=
+-(4\pi S_{\mathrm{def}})^2+O(g),
+\qquad
+\lambda_j^-=O(g^2)\quad(2\le j\le \kappa).
+\]
+故当熵缺口闭合时，全部负方向除主模态外同时二次塌缩；可见缺陷在极限上退化为单一秩一负模。
+\end{theorem}
+
+\begin{proof}
+定理 \ref{thm:xi-entropy-gap-exponential-suppression-nonzero-fingerprint} 给出
+\[
+B:=\sup_{n\ge 1}|u_n|\ll g.
+\]
+又由命题 \ref{prop:xi-defect-entropy-closed-form-invariant} 有 \(u_0=4\pi S_{\mathrm{def}}\)。因此定理 \ref{thm:xi-hankel-spike-singular-spectrum-separation} 立刻给出
+\[
+\sigma_1(\mathsf H_{\kappa-1})\ge |u_0|-\kappa B=4\pi S_{\mathrm{def}}+O(g),
+\qquad
+\sigma_j(\mathsf H_{\kappa-1})\le \kappa B=O(g)\ (j\ge 2).
+\]
+另一方面，
+\[
+\sigma_1(\mathsf H_{\kappa-1})\le |u_0|+\|\mathsf H_{\kappa-1}-u_0e_0e_0^\top\|_{\mathrm{op}}
+=4\pi S_{\mathrm{def}}+O(g),
+\]
+故首个奇异值确有
+\(
+\sigma_1(\mathsf H_{\kappa-1})=4\pi S_{\mathrm{def}}+O(g)
+\)。
+
+最后，由定理 \ref{thm:xi-toeplitz-metric-spectrum-normal-form}，
+\[
+\lambda_j^-=-\sigma_j(\mathsf H_{\kappa-1})^2,
+\]
+代入上述奇异值估计即得所示负广义特征值展开。证毕。
+\end{proof}
+
+\begin{corollary}[良素上的随机补全唯一化]\label{cor:conclusion-goodprime-random-completion-unique-extension}
+设整数序列 \((a_n)_{n\ge 0}\) 的 Hankel 秩为 \(d\)，并取素数 \(p\) 满足
+\[
+\mathsf{Stiff}_p=0.
+\]
+固定任意 \(1\le \delta\le d\)，并仅保留长度 \(2d-\delta\) 的前缀
+\[
+(\bar a_0,\dots,\bar a_{2d-\delta-1}),
+\qquad
+\bar a_n:=a_n\bmod p.
+\]
+将剩余 \(\delta\) 个位置在 \(\FF_p\) 上独立均匀随机补全。则所得长度 \(2d\) 截断以至少
+\[
+1-\frac{d}{p}
+\]
+的概率落入 Hankel 非退化开集，因此唯一延拓为一个 Hankel 秩恰为 \(d\) 的全序列。特别地，在一切良素上都存在成功概率 \(1-O(d/p)\) 的 Las Vegas 型有限域最小 realization 重建程序。
+\end{corollary}
+
+\begin{proof}
+由定理 \ref{thm:pom-stiff0-hankel-good-reduction-dim-stability}，\(\mathsf{Stiff}_p=0\) 蕴含模 \(p\) 约化后的 Hankel 秩仍为 \(d\)。因此真实后缀本身已经给出一个使对应 \(d\times d\) 主块非退化的补全，故补全行列式多项式 \(D(X)\) 非零。于是可直接应用定理 \ref{thm:xi-hankel-finitefield-random-completion-nondegenerate}，得到
+\[
+\Pr[D(X)=0]\le \frac{d}{p},
+\]
+也即成功概率至少为 \(1-d/p\)。一旦 \(\det(H_0(X))\neq 0\)，命题 \ref{prop:xi-hankel-window-fiber-delta} 即给出唯一的秩 \(d\) Hankel 延拓。证毕。
+\end{proof}
+
+\begin{theorem}[判别式支撑的局部--整体统一律]\label{thm:conclusion-discriminant-support-local-global-unification}
+在有限原子指数模型的 \(p\)-整设定下，设特征多项式
+\[
+\chi_A(T)=\prod_{j=1}^{\kappa}(T-z_j),
+\]
+权重为 \(w_1,\dots,w_\kappa\)。则同一判别式支撑同时控制：
+\[
+\text{(a) Archimedean 负谱体积势},
+\qquad
+\text{(b) non-Archimedean 坏素集合}.
+\]
+更精确地，
+\[
+\prod_{i=1}^{\kappa}|\lambda_i^-|
+=(4\pi)^{2\kappa}
+\Bigl(\prod_{j=1}^{\kappa}w_j^2\Bigr)\cdot
+\bigl|\Disc(\chi_A)\bigr|^2,
+\]
+而在 \(p\)-整模型中，
+\[
+H_0\bmod \mathfrak p\ \text{可逆}
+\quad\Longleftrightarrow\quad
+\mathfrak p\nmid
+\Bigl(\prod_{j=1}^{\kappa}w_j\Bigr)\Disc(\chi_A).
+\]
+因此，Archimedean 侧“负谱体积”的消失因子，与 \(p\)-进侧“坏约化”的全部支撑素数，乃由同一判别式对象统一决定。
+\end{theorem}
+
+\begin{proof}
+由定理 \ref{thm:xi-gramshift-bad-primes-weight-discriminant}，
+\[
+\det(\mathsf H_{\kappa-1})
+=(4\pi)^\kappa
+\Bigl(\prod_{j=1}^{\kappa}w_j\Bigr)\Disc(\chi_A).
+\]
+再由推论 \ref{cor:xi-negative-spectrum-product-dethankel-square}，
+\[
+\prod_{i=1}^{\kappa}|\lambda_i^-|
+=
+\bigl|\det(\mathsf H_{\kappa-1})\bigr|^2.
+\]
+将前式代入即可得到
+\[
+\prod_{i=1}^{\kappa}|\lambda_i^-|
+=(4\pi)^{2\kappa}
+\Bigl(\prod_{j=1}^{\kappa}w_j^2\Bigr)\cdot
+\bigl|\Disc(\chi_A)\bigr|^2.
+\]
+
+另一方面，定理 \ref{thm:xi-gramshift-bad-primes-weight-discriminant} 同时给出：在 \(p\)-整模型下，
+\[
+H_0\bmod \mathfrak p\ \text{可逆}
+\iff
+\prod_j w_j\not\equiv 0\pmod{\mathfrak p}
+\ \text{且}\
+\Disc(\chi_A)\not\equiv 0\pmod{\mathfrak p}.
+\]
+这正等价于
+\[
+\mathfrak p\nmid
+\Bigl(\prod_{j=1}^{\kappa}w_j\Bigr)\Disc(\chi_A).
+\]
+故负谱体积与坏素支撑由同一判别式除子统一控制。证毕。
+\end{proof}
+
+\endinput

--- a/theory/2026_golden_ratio_driven_scan_projection_generation_recursive_emergence/sections/body/conclusion/subsec__conclusion-fiber-audit-hodge-congruence-reversible-trisplitting.tex
+++ b/theory/2026_golden_ratio_driven_scan_projection_generation_recursive_emergence/sections/body/conclusion/subsec__conclusion-fiber-audit-hodge-congruence-reversible-trisplitting.tex
@@ -1,0 +1,275 @@
+\subsection{纤维审计的 Hodge--Stein 瓶颈、模同余平方律与可逆三分裂}\label{subsec:conclusion-fiber-audit-hodge-congruence-reversible-trisplitting}
+沿用定理 \ref{thm:pom-fiber-reconstruction-cartesian-product}、定理 \ref{thm:pom-fiber-hodge-stein-tensorization-gap}、定理 \ref{thm:pom-fiber-rewrite-root-of-unity-filter-modq-exp-uniformization}、定理 \ref{thm:pom-root-unity-filter-vartheta-second-order}、推论 \ref{cor:pom-root-unity-filter-q2-law}、推论 \ref{cor:pom-fiber-rewrite-spectrum-no-gaps}、命题 \ref{prop:pom-sufficient-statistic-residual-noninvertibility} 与推论 \ref{cor:pom-reversible-external-residual-kolmogorov-typical-equality} 的记号。前述链条已经分别把纤维重构图的 Cartesian 分解、Hodge--Stein 对偶下的 Poisson 能量极小化、模 \(q\) 根单位滤波的指数均匀化、逆代换次数谱的无缺口区间性、以及仅依赖充分统计量的外置机制之不可逆障碍固定下来。把这些接口并置之后，固定纤维的审计几何可以进一步压缩为一条三轴分裂：能量层只记住最慢谱隙，同余层在大模数下服从平方尺度，可逆层则必须携带独立的对数量级索引复杂度。
+
+\begin{theorem}[纤维 Hodge--Stein 审计的瓶颈原则]\label{thm:conclusion-fiber-hodge-stein-bottleneck-principle}
+若候选位点诱导图满足
+\[
+\Gamma_x\cong \bigsqcup_{i=1}^r P_{\ell_i},
+\]
+则纤维重构图具有 Cartesian 分解
+\[
+\mathcal F_x\cong \prod_{i=1}^r \Gamma_{\ell_i}.
+\]
+在定理 \ref{thm:pom-fiber-hodge-stein-tensorization-gap} 的 Hodge--Stein 口径下，对任意均值零荷载 \(g\in C_0(\mathcal F_x)\)（即 \(\langle g,1\rangle_\pi=0\)），Poisson 方程
+\[
+\Delta u=g
+\]
+在条件 \(\langle u,1\rangle_\pi=0\) 下存在唯一解；并且在全部满足 \(\delta J=g\) 的流中，极小能量流唯一给出为 \(J^\star=-du\)。
+此外，其谱隙满足
+\[
+\lambda_1(\mathcal F_x)=\min_{1\le i\le r}\lambda_1(\Gamma_{\ell_i}).
+\]
+因此，一切由 Hodge--Stein 审计导出的弛豫时间、Poisson 稳定常数与能量恢复速度，都由最慢的单个 Fibonacci 立方因子唯一控制。
+\end{theorem}
+\begin{proof}
+由定理 \ref{thm:pom-fiber-reconstruction-cartesian-product}，
+\[
+\mathcal F_x\cong \prod_{i=1}^r \Gamma_{\ell_i}.
+\]
+将此分解代入定理 \ref{thm:pom-fiber-hodge-stein-tensorization-gap} 的 Cartesian 张量化结论，立即得到：\(\Delta_{\mathcal F_x}\) 为各因子 Laplace 算子的 Kronecker 和，Poisson 方程在均值零子空间上存在唯一解，约束 \(\delta J=g\) 下的最小能量流唯一由 \(J^\star=-du\) 给出，并且
+\[
+\lambda_1(\mathcal F_x)=\min_i\lambda_1(\Gamma_{\ell_i}).
+\]
+故所有以谱隙为控制量的 Hodge--Stein 审计尺度都被最慢因子锁定。证毕。
+\end{proof}
+
+\begin{theorem}[模同余可见律的平方尺度刚性]\label{thm:conclusion-fiber-modq-quadratic-scale-rigidity}
+固定活动度 \(t>0\)。对任意整数 \(q\ge 2\)，记
+\[
+R_x(\omega):=r(\omega),
+\qquad
+R_x^{(q)}:=R_x\bmod q,
+\qquad
+\vartheta(t,q):=\max_{1\le k\le q-1}\frac{\rho(t\zeta_q^k)}{\rho(t)}.
+\]
+则存在常数 \(C(t,q)\in(0,\infty)\) 使得
+\[
+\left\|\mathcal L_t(R_x^{(q)}\mid x)-\mathrm{Unif}(\ZZ/q\ZZ)\right\|_{\mathrm{TV}}
+\le
+\frac{q-1}{2}\,C(t,q)^{c(x)}\,\vartheta(t,q)^{|V(\Gamma_x)|},
+\]
+并且当 \(q\to\infty\) 时，
+\[
+\vartheta(t,q)
+=
+1-\frac{4\pi^2}{q^2}\alpha(t)+O(q^{-4}),
+\qquad
+\alpha(t)>0.
+\]
+若记
+\[
+K(t,q,x):=\frac{q-1}{2}\,C(t,q)^{c(x)},
+\]
+则对任意 \(0<\varepsilon<1\)，条件
+\[
+\left\|\mathcal L_t(R_x^{(q)}\mid x)-\mathrm{Unif}(\ZZ/q\ZZ)\right\|_{\mathrm{TV}}\le \varepsilon
+\]
+在 \(q\to\infty\) 时强制
+\[
+|V(\Gamma_x)|
+\ge
+\frac{q^2}{4\pi^2\alpha(t)}
+\left(\log\frac{K(t,q,x)}{\varepsilon}+O(1)\right).
+\]
+因此，在固定活动度与固定精度阈值下，模 \(q\) 可见性的主导几何代价必为平方尺度。
+\end{theorem}
+\begin{proof}
+总变差界由定理 \ref{thm:pom-fiber-rewrite-root-of-unity-filter-modq-exp-uniformization} 直接给出，而
+\[
+\vartheta(t,q)
+=
+1-\frac{4\pi^2}{q^2}\alpha(t)+O(q^{-4})
+\]
+正是定理 \ref{thm:pom-root-unity-filter-vartheta-second-order} 的结论。将二者合并，并对条件
+\(
+K(t,q,x)\vartheta(t,q)^{|V(\Gamma_x)|}\le \varepsilon
+\)
+取对数，即得到所示下界；这正是推论 \ref{cor:pom-root-unity-filter-q2-law} 的重述。证毕。
+\end{proof}
+
+\begin{theorem}[逆代换计数谱的无缺口性与模偏斜的纯谱来源]\label{thm:conclusion-fiber-nogap-spectrum-purely-spectral-bias}
+若
+\[
+\Gamma_x\cong \bigsqcup_{i=1}^{c(x)} P_{\ell_i},
+\qquad
+R_{\max}(x):=\sum_{i=1}^{c(x)}\left\lceil \frac{\ell_i}{2}\right\rceil,
+\]
+则逆代换次数的全部可取值恰为完整区间
+\[
+\{r(\omega):\ \omega\in \Fold_m^{-1}(x)\}
+=
+\{0,1,2,\dots,R_{\max}(x)\}.
+\]
+特别地，当 \(q\le R_{\max}(x)+1\) 时，每个余类 \(a\in \ZZ/q\ZZ\) 都已有某个原始计数值 \(j\in\{0,\dots,R_{\max}(x)\}\) 满足 \(j\equiv a\pmod q\)。因此，模 \(q\) 分布中的任何偏斜都不能归因于计数支持的缺口，而只能归因于权重项
+\[
+N_j(x)t^j
+\]
+在根单位滤波公式中的非平凡 Fourier 模态。
+\end{theorem}
+\begin{proof}
+推论 \ref{cor:pom-fiber-rewrite-spectrum-no-gaps} 已经给出
+\[
+\{r(\omega):\omega\in\Fold_m^{-1}(x)\}
+=
+\{0,1,\dots,R_{\max}(x)\}.
+\]
+若 \(q\le R_{\max}(x)+1\)，则整数区间 \(\{0,\dots,R_{\max}(x)\}\) 至少含有 \(q\) 个连续整数，因而对每个余类 \(a\in\ZZ/q\ZZ\) 都存在某个 \(j\) 使 \(j\equiv a\pmod q\)。换言之，余类层面并不存在由支持空洞造成的先天缺失。
+
+另一方面，定理 \ref{thm:pom-fiber-rewrite-root-of-unity-filter-modq-exp-uniformization} 给出
+\[
+\PP_t(R_x^{(q)}=a\mid x)
+=
+\frac{1}{q\,Z_x(t)}\sum_{k=0}^{q-1}\zeta_q^{-ak}Z_x(t\zeta_q^k),
+\]
+其中
+\[
+Z_x(t)=\sum_{j\ge 0}N_j(x)t^j.
+\]
+故模 \(q\) 分布的偏斜完全由非平凡根单位通道 \(Z_x(t\zeta_q^k)\) 控制，而非由计数支持缺口控制。证毕。
+\end{proof}
+
+\begin{theorem}[充分统计量的模完备性与可逆外置的指数失真]\label{thm:conclusion-fiber-sufficient-statistic-mod-complete-reversible-distortion}
+固定 \(m\ge 1\) 与 \(x\in X_m\)。设外置残差仅依赖逆代换充分统计量 \(r(\omega)\)，即存在函数 \(g\) 使
+\[
+\mathcal R(\omega)=g(r(\omega))
+\qquad
+(\omega\in\Fold_m^{-1}(x)).
+\]
+则：
+\begin{enumerate}
+  \item 对任意活动度 \(t>0\) 与任意模数 \(q\ge 2\)，模 \(q\) 分布
+  \[
+  \mathcal L_t(R_x^{(q)}\mid x)
+  \]
+  完全由 \(\{N_j(x)\}_{j\ge 0}\) 决定，亦即完全由充分统计量 \(r(\omega)\) 的分布决定；
+  \item 另一方面，像集大小满足
+  \[
+  |\mathcal R(\Fold_m^{-1}(x))|\le d_x+1,
+  \qquad
+  d_x:=\deg Z_x,
+  \]
+  从而当 \(d_m(x)>d_x+1\) 时，映射
+  \[
+  \omega\longmapsto \bigl(x,\mathcal R(\omega)\bigr)
+  \]
+  不可能在纤维上为单射。
+\end{enumerate}
+特别地，在单路径情形
+\[
+\Gamma_x=P_\ell
+\]
+下，
+\[
+d_x=\left\lceil\frac{\ell}{2}\right\rceil,
+\qquad
+d_m(x)=F_{\ell+2},
+\]
+因而任何仅外置 \(r(\omega)\) 的机制，其纤维可逆覆盖比例至多为
+\[
+\frac{d_x+1}{d_m(x)}
+\le
+\frac{\lceil \ell/2\rceil+1}{F_{\ell+2}}
+=
+O(\ell\,\varphi^{-\ell}).
+\]
+因此，同一个统计量 \(r(\omega)\) 在模审计层是完备的，而在可逆外置层却表现出指数级失真。
+\end{theorem}
+\begin{proof}
+第一条直接来自定理 \ref{thm:pom-fiber-rewrite-root-of-unity-filter-modq-exp-uniformization}：
+\[
+\PP_t(R_x^{(q)}=a\mid x)
+=
+\frac{1}{q\,Z_x(t)}\sum_{k=0}^{q-1}\zeta_q^{-ak}Z_x(t\zeta_q^k),
+\qquad
+Z_x(t)=\sum_{j\ge 0}N_j(x)t^j.
+\]
+因此所有模 \(q\) 根单位可见律都只依赖于系数列 \((N_j(x))_j\)，也即只依赖于 \(r(\omega)\) 的分布。
+
+第二条正是命题 \ref{prop:pom-sufficient-statistic-residual-noninvertibility} 的内容。对单路径 \(\Gamma_x=P_\ell\)，该命题给出
+\[
+d_x=\left\lceil\frac{\ell}{2}\right\rceil,
+\qquad
+d_m(x)=F_{\ell+2}.
+\]
+再由 Binet 渐近 \(F_{\ell+2}\asymp \varphi^\ell\)，便得到
+\[
+\frac{d_x+1}{d_m(x)}
+\le
+\frac{\lceil \ell/2\rceil+1}{F_{\ell+2}}
+=
+O(\ell\,\varphi^{-\ell}).
+\]
+证毕。
+\end{proof}
+
+\begin{theorem}[单路径纤维的线性--平方--指数三尺度分裂]\label{thm:conclusion-single-path-linear-quadratic-exponential-splitting}
+在单路径纤维
+\[
+\Gamma_x=P_\ell
+\]
+上，存在三种彼此不可约的自然尺度：
+\[
+R_{\max}(x)+1
+=
+\left\lceil\frac{\ell}{2}\right\rceil+1,
+\]
+\[
+\ell
+\ge
+\frac{q^2}{4\pi^2\alpha(t)}
+\left(\log\frac{K(t,q,x)}{\varepsilon}+O(1)\right)
+\qquad
+\Bigl(\left\|\mathcal L_t(R_x^{(q)}\mid x)-\mathrm{Unif}(\ZZ/q\ZZ)\right\|_{\mathrm{TV}}\le\varepsilon,\ q\to\infty\Bigr),
+\]
+\[
+d_m(x)=F_{\ell+2}.
+\]
+其中第一式给出线性支持尺度，第二式给出模同余可见性的平方主导尺度，第三式给出全纤维微态数的指数尺度。于是，单路径纤维已经同时携带线性、平方与指数三种互不可约的几何层级，任何试图用其中一层单独替代其余两层的审计都不可能完备。
+\end{theorem}
+\begin{proof}
+当 \(\Gamma_x=P_\ell\) 时，定理 \ref{thm:conclusion-fiber-nogap-spectrum-purely-spectral-bias} 给出
+\[
+R_{\max}(x)+1=\left\lceil\frac{\ell}{2}\right\rceil+1,
+\]
+从而支持长度为线性尺度。又因 \(|V(\Gamma_x)|=\ell\) 且 \(c(x)=1\)，定理 \ref{thm:conclusion-fiber-modq-quadratic-scale-rigidity} 立即把固定精度下的模 \(q\) 可见性写成平方主导尺度。最后，由命题 \ref{prop:pom-sufficient-statistic-residual-noninvertibility}，
+\[
+d_m(x)=F_{\ell+2},
+\]
+而 \(F_{\ell+2}\asymp \varphi^\ell\) 给出指数尺度。
+
+三者的增长率分别为线性、平方主导与指数，因而不存在单一尺度函数能够同时恢复它们。证毕。
+\end{proof}
+
+\begin{conjecture}[固定纤维的最小完备审计签名]\label{conj:conclusion-fiber-minimal-complete-audit-signature}
+对固定纤维 \(x\in X_m\)，设
+\[
+\mathfrak S_x
+:=
+\left(
+\lambda_1(\mathcal F_x),\
+\left\{\frac{Z_x(t\zeta_q^k)}{Z_x(t)}\right\}_{q\ge 2,\ 1\le k<q},\
+\mathsf i_x
+\right),
+\]
+其中 \(\mathsf i_x\) 表示任意一个在纤维 \(\Fold_m^{-1}(x)\) 上实现精确可逆恢复的索引残差，并满足
+\[
+K\bigl(\mathsf i_x(\omega)\mid x,m\bigr)=\log_2 d_m(x)\pm O(1)
+\]
+在纤维均匀分布下以概率 \(1-2^{-\Omega(1)}\) 成立。
+则若一个审计体系同时要求：
+\begin{enumerate}
+  \item Hodge--Stein 能量与 Poisson 稳定性可核验；
+  \item 全部模 \(q\) 同余统计可核验；
+  \item 微态可逆重构的最小索引复杂度可核验；
+\end{enumerate}
+则任意普适完备签名都应当经由 \(\mathfrak S_x\) 的某个等价形式因子化；并且删去其中任一分量，完备性即失效。
+\end{conjecture}
+
+\noindent
+该猜想的支撑来自三条彼此正交的已证链。首先，定理 \ref{thm:conclusion-fiber-hodge-stein-bottleneck-principle} 表明 \(\lambda_1(\mathcal F_x)\) 已经是能量弛豫层的最小充分量。其次，定理 \ref{thm:conclusion-fiber-modq-quadratic-scale-rigidity} 与定理 \ref{thm:conclusion-fiber-nogap-spectrum-purely-spectral-bias} 表明，归一化根单位采样
+\[
+\left\{\frac{Z_x(t\zeta_q^k)}{Z_x(t)}\right\}_{q,k}
+\]
+承载全部模同余可见律。最后，定理 \ref{thm:conclusion-fiber-sufficient-statistic-mod-complete-reversible-distortion} 与推论 \ref{cor:pom-reversible-external-residual-kolmogorov-typical-equality} 表明，可逆索引层必须独立支付 \(\log_2 d_m(x)\) 量级的复杂度，而这一量既不由谱隙决定，也不由根单位滤波决定。于是，固定纤维的审计几何自然分裂为能量几何、模可见几何与可逆信息几何三条互不替代的资源轴。
+
+\endinput

--- a/theory/2026_golden_ratio_driven_scan_projection_generation_recursive_emergence/sections/body/conclusion/subsec__conclusion-finite-primesupport-boolean-exact-uniaxial-register.tex
+++ b/theory/2026_golden_ratio_driven_scan_projection_generation_recursive_emergence/sections/body/conclusion/subsec__conclusion-finite-primesupport-boolean-exact-uniaxial-register.tex
@@ -1,0 +1,278 @@
+\subsection{有限素数支撑的 Boolean exact calculus 与一轴 prime-register 的有限支撑骨架}\label{subsec:conclusion-finite-primesupport-boolean-exact-uniaxial-register}
+沿用定理
+\ref{thm:killo-localization-circle-dimension-prime-ledger-splitting}、
+\ref{thm:conclusion-finite-prime-solenoid-terminal-object}、
+\ref{thm:conclusion-finite-prime-localization-pontryagin-rigidity}、
+\ref{thm:xi-localized-phase-sampling-closed-form}、
+\ref{thm:killo-godel-semidir-affine-2adic}
+与猜想
+\ref{conj:conclusion-uniaxial-prime-register-universality}
+的记号。前述结果已经分别给出：有限素数局部化的 Pontryagin 对偶短正合列、有限 prime-support completion 的终对象性与刚性分类、局部化相位采样对有限素数支撑的唯一恢复，以及 canonical finite-time-depth prime-register 在固定二维 \(2\)-进 Tate 模块上的忠实仿射实现。把这些接口并读之后，可进一步把有限素数支撑提升为一套在 compact--profinite 侧可做精确商、精确交与精确粘接的 Boolean exact calculus。
+
+\begin{theorem}[有限素数支撑的精确商]\label{thm:conclusion-finite-primesupport-exact-quotient}
+对任意有限素数集
+\[
+S\subseteq T\subset \mathbb P,
+\qquad
+G_S:=\ZZ[S^{-1}],
+\qquad
+\Sigma_S:=\widehat{G_S},
+\]
+存在自然短正合列
+\[
+0\longrightarrow \prod_{p\in T\setminus S}\ZZ_p
+\longrightarrow \Sigma_T
+\xrightarrow{\ q_{T\to S}\ }
+\Sigma_S
+\longrightarrow 0.
+\]
+特别地，删去有限素数支撑中的每一个新增素数 \(p\in T\setminus S\)，在对偶侧恰对应于剥去一个 \(p\)-进因子 \(\ZZ_p\)，而连通圆因子保持不变。
+\end{theorem}
+\begin{proof}
+由定理 \ref{thm:killo-localization-circle-dimension-prime-ledger-splitting}，对任意有限 \(U\subset \mathbb P\) 都有
+\[
+0\longrightarrow \ZZ\longrightarrow G_U\longrightarrow \bigoplus_{p\in U}C_{p^\infty}\longrightarrow 0
+\]
+及其 Pontryagin 对偶
+\[
+0\longrightarrow \prod_{p\in U}\ZZ_p\longrightarrow \Sigma_U\longrightarrow \TT\longrightarrow 0.
+\]
+当 \(S\subseteq T\) 时，离散侧有自然嵌入
+\[
+G_S=\ZZ[S^{-1}]\hookrightarrow \ZZ[T^{-1}]=G_T,
+\]
+并且商群恰为
+\[
+G_T/G_S\cong \bigoplus_{p\in T\setminus S}C_{p^\infty},
+\]
+因为新增的分母自由度正好来自 \(T\setminus S\) 中各素数的 Prüfer 塔。对该短正合列取 Pontryagin 对偶，便得到
+\[
+0\longrightarrow \prod_{p\in T\setminus S}\ZZ_p
+\longrightarrow \Sigma_T
+\xrightarrow{\ q_{T\to S}\ }
+\Sigma_S
+\longrightarrow 0.
+\]
+最后，由定理 \ref{thm:conclusion-finite-prime-solenoid-terminal-object}，每个 \(\Sigma_U\) 的非平凡连通 Lie 可见商都同构于 \(\TT\)，故上述商映射只剥去全不连通 prime-ledger 核，而不改变唯一的连通圆因子。证毕。
+\end{proof}
+
+\begin{theorem}[有限素数支撑的 Boolean--exact 双笛卡尔演算]\label{thm:conclusion-finite-primesupport-bicartesian-boolean-calculus}
+对任意有限素数集 \(S,T\subset \mathbb P\)，存在自然短正合列
+\[
+0\longrightarrow \Sigma_{S\cup T}
+\longrightarrow \Sigma_S\times \Sigma_T
+\xrightarrow{\ \delta\ }
+\Sigma_{S\cap T}
+\longrightarrow 0,
+\]
+其中
+\[
+\delta(x,y):=q_{S\to S\cap T}(x)-q_{T\to S\cap T}(y).
+\]
+因此，在 compact abelian groups 范畴中，方块
+\[
+\begin{matrix}
+\Sigma_{S\cup T} &\longrightarrow& \Sigma_S\\
+\downarrow && \downarrow\\
+\Sigma_T &\longrightarrow& \Sigma_{S\cap T}
+\end{matrix}
+\]
+同时是 pullback 与 pushout。换言之，有限素数支撑的并、交两种 Boolean 运算，在相位完成侧严格实现为一条双笛卡尔 exact calculus。
+\end{theorem}
+\begin{proof}
+在离散侧考虑自然加法映射
+\[
+\psi:G_S\oplus G_T\longrightarrow G_{S\cup T},
+\qquad
+\psi(x,y):=x+y.
+\]
+先证其满射。任取
+\[
+z\in G_{S\cup T}.
+\]
+可将其写成
+\[
+z=\frac{a}{cmn},
+\]
+其中 \(c\) 的素数支撑包含于 \(S\cap T\)，\(m\) 的素数支撑包含于 \(S\setminus T\)，\(n\) 的素数支撑包含于 \(T\setminus S\)。于是 \((m,n)=1\)，故存在整数 \(\alpha,\beta\) 使
+\[
+\alpha m+\beta n=1.
+\]
+从而
+\[
+z=\frac{a}{cmn}
+=
+\frac{a\beta}{cm}+\frac{a\alpha}{cn},
+\]
+其中
+\[
+\frac{a\beta}{cm}\in G_S,
+\qquad
+\frac{a\alpha}{cn}\in G_T.
+\]
+故 \(\psi\) 满射。
+
+其核恰为反对角嵌入的 \(G_{S\cap T}\)：若 \(x+y=0\)，则
+\[
+x=-y\in G_S\cap G_T=G_{S\cap T},
+\]
+反之任取 \(z\in G_{S\cap T}\)，对偶对 \((z,-z)\) 显然落在核中。故有短正合列
+\[
+0\longrightarrow G_{S\cap T}
+\longrightarrow G_S\oplus G_T
+\longrightarrow G_{S\cup T}
+\longrightarrow 0.
+\]
+对偶化后得到
+\[
+0\longrightarrow \Sigma_{S\cup T}
+\longrightarrow \Sigma_S\times \Sigma_T
+\xrightarrow{\ \delta\ }
+\Sigma_{S\cap T}
+\longrightarrow 0.
+\]
+而 Pontryagin 对偶把离散交换群范畴与紧交换群范畴反变等价；在离散侧，此短正合列正对应于并/交的标准 Mayer--Vietoris 型演算，因此在对偶侧对应方块同时给出 fiber product 与 amalgamated pushout。证毕。
+\end{proof}
+
+\begin{theorem}[实现层二维与结构层一圆维的严格分离]\label{thm:conclusion-prime-register-twoadic-implementation-onecircle-structure-separation}
+设
+\[
+H_{\mathrm{can}}
+\]
+为任意 canonical finite-time-depth prime-register 子单子。则同时成立：
+\begin{enumerate}
+  \item \(H_{\mathrm{can}}\) 可忠实实现为固定二维 \(2\)-进 Tate 模块
+  \[
+  T_2(E_{\min})\cong \ZZ_2^2
+  \]
+  上的仿射变换单子；
+  \item 任意由局部化相位采样恢复的有限 prime-support 对象，其结构层只对应某个
+  \[
+  G_S=\ZZ[S^{-1}]
+  \]
+  及其对偶短正合列
+  \[
+  0\longrightarrow \prod_{p\in S}\ZZ_p\longrightarrow \Sigma_S\longrightarrow \TT\longrightarrow 0;
+  \]
+  \item 这些结构层对象恒满足
+  \[
+  \cdim_{\mathrm{fr}}(G_S)=1.
+  \]
+\end{enumerate}
+因此，prime-register 机制在实现层上最小需要二维 \(2\)-进 ambient space，而在结构层上始终只携带唯一的连通圆因子；第二个 \(2\)-进方向只是 faithful realization 的工作坐标，而不是额外的结构圆维。
+\end{theorem}
+\begin{proof}
+第一条正是定理 \ref{thm:killo-godel-semidir-affine-2adic} 的内容：任意 canonical finite-time-depth prime-register 机制都可忠实嵌入
+\[
+\mathrm{Aff}\!\bigl(T_2(E_{\min})\bigr),
+\qquad
+T_2(E_{\min})\cong \ZZ_2^2.
+\]
+第二条由定理 \ref{thm:xi-localized-phase-sampling-closed-form} 与定理 \ref{thm:conclusion-finite-prime-localization-pontryagin-rigidity} 给出：局部化相位采样只能唯一恢复有限素数集 \(S\)，等价地只能恢复
+\[
+0\to \prod_{p\in S}\ZZ_p\to \Sigma_S\to \TT\to 0
+\]
+中的 prime-ledger 核。第三条则是定理 \ref{thm:killo-localization-circle-dimension-prime-ledger-splitting} 的直接内容。
+
+最后，由定理 \ref{thm:conclusion-finite-prime-solenoid-terminal-object}，\(\Sigma_S\) 的任意非平凡连通紧 Lie 商都同构于 \(\TT\)。因此二维 \(2\)-进实现空间并不意味着结构层存在第二个连通圆方向；它只是在 faithful implementation 中用于承载仿射动力学的 ambient coordinate。证毕。
+\end{proof}
+
+\begin{theorem}[有限素数支撑包含关系的商映射判别]\label{thm:conclusion-finite-primesupport-quotient-order-characterization}
+对任意有限素数集 \(S,T\subset \mathbb P\)，下列命题等价：
+\begin{enumerate}
+  \item \(S\subseteq T\)；
+  \item 存在连续满射
+  \[
+  q:\Sigma_T\twoheadrightarrow \Sigma_S
+  \]
+  ，其核全不连通，并且在标准圆商上满足
+  \[
+  \pi_S\circ q=\pi_T,
+  \]
+  其中 \(\pi_U:\Sigma_U\twoheadrightarrow \TT\) 是定理 \ref{thm:conclusion-finite-prime-solenoid-terminal-object} 中的标准投影；
+  \item 存在离散侧单射
+  \[
+  \iota:G_S\hookrightarrow G_T.
+  \]
+\end{enumerate}
+因此，有限素数支撑的包含关系，可以完全在 compact 完成侧用“是否存在带全不连通核的标准商映射”来刻画。
+\end{theorem}
+\begin{proof}
+\(1\Rightarrow 2\) 正是定理 \ref{thm:conclusion-finite-primesupport-exact-quotient}，其中 \(q=q_{T\to S}\)。
+
+\(2\Rightarrow 3\) 由 Pontryagin 对偶直接得到：连续满射 \(q\) 的对偶是离散侧单射
+\[
+\widehat q:G_S\hookrightarrow G_T.
+\]
+
+现证 \(3\Rightarrow 1\)。设 \(\iota:G_S\hookrightarrow G_T\) 为单射。若 \(p\in S\)，则 \(1\in G_S\) 是 \(p\)-可除的，因为
+\[
+1=p\cdot \frac{1}{p}
+\qquad\text{且}\qquad
+\frac{1}{p}\in G_S.
+\]
+更强地，对每个 \(n\ge 1\) 都有
+\[
+1=p^n\cdot \frac{1}{p^n},
+\qquad
+\frac{1}{p^n}\in G_S,
+\]
+故 \(\iota(1)\neq 0\) 在 \(G_T\) 中对一切 \(n\) 都是 \(p^n\)-可除的。若 \(p\notin T\)，则 \(G_T=\ZZ[T^{-1}]\) 中不存在非零的无限 \(p\)-可除元素：任取
+\[
+x=\frac{a}{\prod_{q\in T}q^{k_q}}\neq 0,
+\]
+若对每个 \(n\) 都存在 \(y_n\in G_T\) 使 \(x=p^n y_n\)，则分子 \(a\) 必被任意高次 \(p\) 整除，只能推出 \(a=0\)，与 \(x\neq 0\) 矛盾。因此 \(p\notin T\) 不可能。故 \(p\in T\)，从而 \(S\subseteq T\)。证毕。
+\end{proof}
+
+\begin{corollary}[有限素数支撑完成族的完全 Boolean 实现]\label{cor:conclusion-finite-primesupport-boolean-exact-realization}
+赋值
+\[
+S\longmapsto \Sigma_S
+\]
+把有限素数支撑的 Boolean 格
+\[
+(\mathcal P_f(\mathbb P),\cup,\cap)
+\]
+完全实现到 compact abelian groups 范畴中，并满足
+\[
+\Sigma_{S\cup T}
+\cong
+\Sigma_S\times_{\Sigma_{S\cap T}}\Sigma_T,
+\]
+\[
+S\subseteq T
+\iff
+\exists\,\Sigma_T\twoheadrightarrow \Sigma_S
+\text{ with totally disconnected kernel}.
+\]
+因此，项目中的有限 prime-stage 已不再只是标签集合，而是一套可在 exact 范畴语义下完整演算的 Boolean support calculus。
+\end{corollary}
+\begin{proof}
+第一条正是定理 \ref{thm:conclusion-finite-primesupport-bicartesian-boolean-calculus} 对 kernel 的 fiber-product 解释；第二条正是定理 \ref{thm:conclusion-finite-primesupport-quotient-order-characterization}。证毕。
+\end{proof}
+
+\begin{conjecture}[一轴 prime-register 的有限支撑逆极限骨架]\label{conj:conclusion-finite-primesupport-universal-inverse-limit-solenoid}
+沿有限素数支撑格的包含关系，以定理 \ref{thm:conclusion-finite-primesupport-exact-quotient} 的过渡映射
+\[
+q_{T\to S}:\Sigma_T\twoheadrightarrow \Sigma_S
+\qquad (S\subseteq T)
+\]
+组织出的 inverse system
+\[
+\bigl(\Sigma_S,q_{T\to S}\bigr)_{S\in \mathcal P_f(\mathbb P)}
+\]
+应当给出猜想 \ref{conj:conclusion-uniaxial-prime-register-universality} 中一轴 prime-register 普适对象的有限支撑骨架；更精确地，存在规范同构
+\[
+\Sigma_{\mathrm{univ}}
+\cong
+\varprojlim_{S\in \mathcal P_f(\mathbb P)}\Sigma_S.
+\]
+若此猜想成立，则：
+\begin{enumerate}
+  \item 定理 \ref{thm:conclusion-finite-primesupport-exact-quotient}--\ref{thm:conclusion-finite-primesupport-quotient-order-characterization} 所给出的 finite-support Boolean exact calculus 将汇聚为一个真正的 universal one-axis phase register；
+  \item 全部有限 prime-stage completions 都将成为该一轴对象的 cofinal 商；
+  \item “有限状态不可逆性可由单轴 prime-register 逆极限统一吸收”将由有限支撑近似提升为严格的 inverse-limit theorem。
+\end{enumerate}
+\end{conjecture}
+
+上述链条把有限素数局部化、局部化相位采样与 canonical prime-register 的 faithful implementation 压成了同一骨架：有限素数支撑在 compact--profinite 侧并非一组松散标签，而是携带精确商、精确交与精确粘接的 Boolean exact calculus；而一轴 prime-register 的普适性，则应当正是这套 finite-support exact calculus 的 cofinal inverse-limit completion。

--- a/theory/2026_golden_ratio_driven_scan_projection_generation_recursive_emergence/sections/body/conclusion/subsec__conclusion-freezing-capacity-samplepattern-audit-register-trisplitting.tex
+++ b/theory/2026_golden_ratio_driven_scan_projection_generation_recursive_emergence/sections/body/conclusion/subsec__conclusion-freezing-capacity-samplepattern-audit-register-trisplitting.tex
@@ -1,0 +1,419 @@
+\subsection{冻结截断、容量全息与统计审计的三寄存器分裂}\label{subsec:conclusion-freezing-capacity-samplepattern-audit-register-trisplitting}
+沿用小节 \ref{subsec:conclusion-maxfiber-freezing-capacity-entropy-separation}、小节 \ref{subsec:conclusion-capacity-mellin-thermodynamic-wedderburn-holography}、小节 \ref{subsec:conclusion-capacity-majorization-infonce-complexity-separation} 与定理 \ref{thm:conclusion-sample-pattern-family-closes-hot-thermodynamics} 的记号。前述结果已经分别给出：亚极大预算下仅最大纤维受截断的容量平台、冻结相 escort 测度在全 Rényi 轴与全变差上的指数塌缩、连续容量曲线与 Wedderburn 块谱的完备对应、有限样本相等模式对对称接口的全恢复，以及完整 Bayes--InfoNCE 数值塔对有序纤维谱的最小连续层析。把这些接口并读之后，还可抽出一条更高层的闭合链：冻结前沿、容量全息、样本模式热相几何与统计审计塔并非同一信息的不同近似，而是三条彼此不可替代的 faithful 坐标轴。
+
+\begin{theorem}[亚极大预算窗的单层截断律]\label{thm:conclusion-subcritical-budget-single-layer-truncation}
+记
+\[
+M_m:=\max_{x\in X_m}d_m(x),
+\qquad
+K_m:=\#\{x\in X_m:\ d_m(x)=M_m\},
+\]
+\[
+M_m^{(2)}:=\max\{d_m(x):\ d_m(x)<M_m\},
+\qquad
+\alpha_\ast:=\lim_{m\to\infty}\frac{1}{m}\log M_m,
+\]
+\[
+g_\ast:=\lim_{m\to\infty}\frac{1}{m}\log K_m,
+\qquad
+\alpha_\ast^{(2)}:=\limsup_{m\to\infty}\frac{1}{m}\log M_m^{(2)}.
+\]
+设整数预算序列 \((B_m)_{m\ge 1}\) 满足
+\[
+\beta:=\lim_{m\to\infty}\frac{1}{m}\log 2^{B_m}
+\]
+存在，且
+\[
+\alpha_\ast^{(2)}<\beta<\alpha_\ast.
+\]
+则对充分大的 \(m\) 恰有
+\[
+C_m(B_m)=2^m-K_m\bigl(M_m-2^{B_m}\bigr),
+\]
+从而
+\[
+1-\mathrm{Succ}_m(B_m)
+=
+\frac{K_m(M_m-2^{B_m})}{2^m}.
+\]
+特别地，
+\[
+\lim_{m\to\infty}\frac{1}{m}\log\bigl(1-\mathrm{Succ}_m(B_m)\bigr)
+=
+\alpha_\ast+g_\ast-\log 2.
+\]
+因此，在该预算窗内，预算 \(2^{B_m}\) 只截断最大纤维层，而对一切严格次大纤维完全透明。
+\end{theorem}
+\begin{proof}
+定理 \ref{thm:conclusion-subcritical-maxfiber-capacity-platform} 已给出
+\[
+C_m(B_m)=2^m-K_m\bigl(M_m-2^{B_m}\bigr)
+\]
+及其指数率结论。其证明同时表明：由
+\[
+\alpha_\ast^{(2)}<\beta<\alpha_\ast
+\]
+可得对充分大的 \(m\) 有
+\[
+M_m^{(2)}<2^{B_m}<M_m,
+\]
+故所有严格次大纤维都被预算完全覆盖，而仅最大纤维被截断。再把
+\[
+\mathrm{Succ}_m(B)=\frac{C_m(B)}{2^m}
+\]
+代入即可得到
+\[
+1-\mathrm{Succ}_m(B_m)
+=
+\frac{K_m(M_m-2^{B_m})}{2^m},
+\]
+从而得到所述单层截断律。证毕。
+\end{proof}
+
+\begin{theorem}[冻结相的全轴熵与全变差塌缩]\label{thm:conclusion-freezing-measure-collapse-all-axes}
+定义冻结阈值
+\[
+a_{\mathrm c}:=\frac{\log\varphi-g_\ast}{\alpha_\ast-\alpha_\ast^{(2)}},
+\]
+并在 \(a>a_{\mathrm c}\) 时定义 escort 分布
+\[
+\pi_{m,a}(x):=\frac{d_m(x)^a}{S_a(m)},
+\qquad
+S_a(m):=\sum_{x\in X_m}d_m(x)^a.
+\]
+再记
+\[
+A_m^{\max}:=\{x\in X_m:\ d_m(x)=M_m\},
+\qquad
+U_m^{\max}:=\mathrm{Unif}(A_m^{\max}).
+\]
+则对每个 \(a>a_{\mathrm c}\) 都有
+\[
+\pi_{m,a}(A_m^{\max})
+\ge
+1-\exp\!\bigl(-m\Delta(a)+o(m)\bigr),
+\]
+\[
+\Delta(a):=a(\alpha_\ast-\alpha_\ast^{(2)})-(\log\varphi-g_\ast)>0,
+\]
+并且对每个 \(s\in[1,\infty]\),
+\[
+\lim_{m\to\infty}\frac{1}{m}H_s(\pi_{m,a})=g_\ast.
+\]
+此外还有精确恒等式
+\[
+\bigl|\pi_{m,a}-U_m^{\max}\bigr|_{\mathrm{TV}}
+=
+1-\pi_{m,a}(A_m^{\max})
+\le
+\exp\!\bigl(-m\Delta(a)+o(m)\bigr).
+\]
+因此，冻结相并不只是压力函数在高阶矩上的线性化，而是 escort 测度在质量、Shannon/R\'enyi 熵率与全变差几何上的同步塌缩。
+\end{theorem}
+\begin{proof}
+由定理 \ref{thm:conclusion-frozen-escort-shannon-renyi-collapse}，当 \(a>a_{\mathrm c}\) 时有
+\[
+\pi_{m,a}(A_m^{\max})
+\ge
+1-\exp\!\bigl(-m\Delta(a)+o(m)\bigr),
+\]
+并且 Shannon 熵率与任意固定有限 Rényi 阶都收敛到 \(g_\ast\)。再由推论 \ref{cor:conclusion-frozen-escort-all-renyi-collapse}，该结论延伸到全部 \(s\in[1,\infty]\)。最后，定理 \ref{thm:conclusion-frozen-escort-tv-rigidity} 给出精确全变差恒等式
+\[
+\bigl|\pi_{m,a}-U_m^{\max}\bigr|_{\mathrm{TV}}
+=
+1-\pi_{m,a}(A_m^{\max}),
+\]
+以及相同指数率的上界。三者合并即得结论。证毕。
+\end{proof}
+
+\begin{theorem}[连续容量曲线的热力学--Wedderburn 完备性]\label{thm:conclusion-capacity-wedderburn-thermodynamic-completeness}
+固定分辨率 \(m\)。定义连续容量曲线
+\[
+\mathcal C_m^{\mathrm{cont}}(T):=\sum_{x\in X_m}\min(d_m(x),T)
+\qquad (T\ge 0),
+\]
+尾计数函数
+\[
+N_m(T):=\#\{x\in X_m:\ d_m(x)\ge T\},
+\]
+直方图
+\[
+h_m(d):=\#\{x\in X_m:\ d_m(x)=d\},
+\]
+以及纤维群胚代数
+\[
+A_m:=\mathbf C[R_m^{\mathrm{bin}}].
+\]
+则下列四类对象彼此唯一决定：
+\[
+\mathcal C_m^{\mathrm{cont}}(\cdot)
+\Longleftrightarrow
+N_m(\cdot)
+\Longleftrightarrow
+h_m(\cdot)
+\Longleftrightarrow
+A_m\simeq \bigoplus_{d\ge 1}M_d(\mathbf C)^{\oplus h_m(d)}.
+\]
+并且对任意 \(q>0\)，有
+\[
+S_q(m):=\sum_{x\in X_m}d_m(x)^q
+=
+q\int_0^\infty T^{q-1}N_m(T)\,\dd T,
+\]
+从而全部正阶矩谱也由 \(\mathcal C_m^{\mathrm{cont}}\) 唯一恢复。
+
+更强地，若
+\[
+f:\Omega\to X,
+\qquad
+g:X\to Y,
+\qquad
+h:=g\circ f,
+\]
+并记
+\[
+X_+:=\{x\in X:\ d_f(x)>0\},
+\]
+则
+\[
+\mathcal C_h^{\mathrm{cont}}(T)=\mathcal C_f^{\mathrm{cont}}(T)
+\qquad (\forall T\ge 0)
+\]
+当且仅当 \(g|_{X_+}\) 单射。因而，任何真正合并正纤维的粗粒化，都不可能同时在容量曲线、全部正阶矩谱与 Wedderburn 块谱三侧隐身。
+\end{theorem}
+\begin{proof}
+定理 \ref{thm:conclusion-wedderburn-threshold-holography} 已证明
+\[
+\mathcal C_m^{\mathrm{cont}}(\cdot)
+\Longleftrightarrow
+N_m(\cdot)
+\Longleftrightarrow
+h_m(\cdot)
+\Longleftrightarrow
+A_m\simeq \bigoplus_{d\ge 1}M_d(\mathbf C)^{\oplus h_m(d)}.
+\]
+另一方面，对任意 \(q>0\) 与任意正整数 \(d\)，都有
+\[
+d^q=q\int_0^d T^{q-1}\,\dd T.
+\]
+对 \(d=d_m(x)\) 求和并交换求和与积分，得到
+\[
+S_q(m)
+=
+q\int_0^\infty T^{q-1}\#\{x\in X_m:\ d_m(x)\ge T\}\,\dd T
+=
+q\int_0^\infty T^{q-1}N_m(T)\,\dd T.
+\]
+故全部正阶矩谱也由 \(N_m\)，从而由 \(\mathcal C_m^{\mathrm{cont}}\) 唯一决定。
+
+最后，粗粒化判据正是定理 \ref{thm:conclusion-coarsening-global-rigidity-of-capacity-curve} 的结论：若 \(g|_{X_+}\) 非单射，则存在两个正纤维被真合并，导致某个阈值区间上
+\[
+\mathcal C_h^{\mathrm{cont}}(T)<\mathcal C_f^{\mathrm{cont}}(T);
+\]
+反之若 \(g|_{X_+}\) 单射，则正纤维多重集只被重标号，容量曲线保持不变。证毕。
+\end{proof}
+
+\begin{theorem}[样本相等模式与 Bayes 深尾律的双参数闭包]\label{thm:conclusion-sample-pattern-deeptail-top-geometry-completeness}
+固定分辨率 \(m\)，记
+\[
+N:=|X_m|,
+\qquad
+w_i:=\frac{d_i}{2^m}
+\qquad (1\le i\le N)
+\]
+为按非增序排列的纤维权重。令 \(\Pi_N\) 表示 \(N\) 个独立样本
+\[
+X_1,\dots,X_N\sim (w_1,\dots,w_N)
+\]
+的相等模式分割，并记 Pareto 上边界为 \(H_m^{\mathrm{orc}}:=H_m\)。则 \(\mathrm{Law}(\Pi_N)\) 唯一决定
+\[
+\{w_i\}_{i=1}^{N},
+\qquad
+\{S_q(m)\}_{q\in\RR},
+\qquad
+H_m^{\mathrm{orc}},
+\qquad
+\{\mathrm{Succ}^{\mathrm{orc}}_m(B)\}_{B\ge 0}.
+\]
+
+进一步，若
+\[
+w_1=\cdots=w_{r_\ast}=w_\ast>w_{r_\ast+1}\ge\cdots\ge w_N>0,
+\]
+并定义
+\[
+h_t(w):=[z^t]\prod_{i=1}^{N}(1-w_i z)^{-1},
+\qquad
+T(\varepsilon):=\min\{t\ge 0:\ h_t(w)\le \varepsilon\},
+\]
+则存在常数 \(C_w>0\) 使
+\[
+h_t(w)=C_w\,t^{r_\ast-1}w_\ast^t\bigl(1+O(t^{-1})\bigr),
+\]
+从而
+\[
+w_\ast=\lim_{t\to\infty}\frac{h_{t+1}(w)}{h_t(w)},
+\qquad
+r_\ast
+=
+1+\lim_{t\to\infty}
+t\left(\frac{h_{t+1}(w)}{w_\ast h_t(w)}-1\right),
+\]
+并且当 \(\varepsilon\downarrow 0\) 时，
+\[
+T(\varepsilon)
+=
+\frac{\log(1/\varepsilon)}{\log(1/w_\ast)}
++
+\frac{r_\ast-1}{\log(1/w_\ast)}\log\log(1/\varepsilon)
++
+O(1).
+\]
+因此，有限样本相等模式恢复的是完整有限谱，而深尾 Bayes 查询恢复的是顶端权 \(w_\ast\) 与顶端重数 \(r_\ast\) 的双参数几何。
+\end{theorem}
+\begin{proof}
+定理 \ref{thm:conclusion-sample-pattern-complete-symmetric-interface} 已经说明：\(\mathrm{Law}(\Pi_N)\) 唯一决定有序权重多重集、全部幂和谱、Pareto 上边界以及整条有限分辨率预言机成功曲线。另一方面，定理 \ref{thm:conclusion-bayes-full-recovery-top-pole} 给出
+\[
+h_t(w)=C_w\,t^{r_\ast-1}w_\ast^t\bigl(1+O(t^{-1})\bigr),
+\]
+并由相邻比值恢复 \(w_\ast\) 与 \(r_\ast\)。最后，推论 \ref{cor:conclusion-bayes-deep-tail-two-parameter-log-law} 正给出阈值
+\[
+T(\varepsilon)
+\]
+的双参数对数律。三者合并即得结论。证毕。
+\end{proof}
+
+\begin{theorem}[热相接触几何由样本模式族完全闭合]\label{thm:conclusion-sample-pattern-family-closes-hot-contact-geometry}
+设热相区间为 \((a_0,a_1)\)，记预言机容量指数为 \(\Gamma_{\mathrm{orc}}(a)\)，共轭参数为 \(q_\ast(a)\in(0,1)\)，实参数压力为 \(\tau(q)\)，多重分形前沿为 \(f(a)\)。则在热相内有严格互反公式
+\[
+q_\ast(a)=1-\Gamma_{\mathrm{orc}}'(a),
+\qquad
+a=\tau'(q_\ast(a)),
+\]
+\[
+\tau(q_\ast(a))
+=
+\Gamma_{\mathrm{orc}}(a)-a\,\Gamma_{\mathrm{orc}}'(a),
+\qquad
+\tau''(q_\ast(a))=-\frac{1}{\Gamma_{\mathrm{orc}}''(a)}.
+\]
+并且
+\[
+\Gamma_{\mathrm{orc}}(a)=f(a)+a
+\]
+在整个热相中没有幽灵扇区：每个 \(a\in(a_0,a_1)\) 都由唯一真实接触点 \(\alpha=a\) 暴露。更强地，跨尺度样本模式族
+\[
+\{\mathrm{Law}(\Pi_{|X_m|})\}_{m\ge 1}
+\]
+唯一决定热相中的全部对象
+\[
+f(a),
+\qquad
+\tau(q),
+\qquad
+a\longleftrightarrow q_\ast(a).
+\]
+\end{theorem}
+\begin{proof}
+定理 \ref{thm:conclusion-hot-phase-oracle-legendre-reciprocity} 已给出题述四个互反公式。定理 \ref{thm:conclusion-hot-phase-no-ghost-sector} 进一步说明
+\[
+\Gamma_{\mathrm{orc}}''(a)<0,
+\qquad
+a\longmapsto q_\ast(a)
+\]
+是从 \((a_0,a_1)\) 到 \((0,1)\) 的 \(C^1\)-微分同胚，故热相内不存在伪暴露扇区。最后，定理 \ref{thm:conclusion-sample-pattern-family-closes-hot-thermodynamics} 已证明跨尺度样本模式族唯一决定 \(\Gamma_{\mathrm{orc}}\)，从而经由上述互反公式唯一恢复 \(f\)、\(\tau\) 与 \(a\leftrightarrow q_\ast(a)\)。证毕。
+\end{proof}
+
+\begin{theorem}[主序--容量--完整 Bayes--InfoNCE 塔的严格反向同构]\label{thm:conclusion-majorization-capacity-infonce-strict-antiisomorphism}
+固定总质量 \(S\) 与可见类型数 \(N\)，记
+\[
+\mathcal S_{S,N}
+:=
+\left\{
+\mathbf d=(d_1,\dots,d_N)\in \ZZ_{\ge 1}^N:
+d_1\ge\cdots\ge d_N,\ \sum_{i=1}^{N}d_i=S
+\right\}.
+\]
+对每个 \(\mathbf d\in\mathcal S_{S,N}\)，定义连续容量曲线
+\[
+C_{\mathbf d}(u):=\sum_{i=1}^{N}\min(d_i,u)
+\qquad (u\ge 0),
+\]
+并令
+\[
+\mathscr L_{\mathbf d}
+:=
+\bigl(L_2^\star(\mathbf d),L_3^\star(\mathbf d),\dots,L_N^\star(\mathbf d)\bigr)
+\]
+表示把归一化谱 \(\mathbf d/S\) 代入 fixed-resolution Bayes--InfoNCE 最优闭式后所得的完整数值塔。则
+\[
+\mathbf d\succcurlyeq_{\mathrm{HLP}}\mathbf e
+\iff
+C_{\mathbf d}(u)\le C_{\mathbf e}(u)\ \ (\forall u\ge 0)
+\iff
+\mathscr L_{\mathbf d}\preccurlyeq_{\mathrm{InfoNCE}}\mathscr L_{\mathbf e},
+\]
+其中 \(\succcurlyeq_{\mathrm{HLP}}\) 为 Hardy--Littlewood--P\'olya 主序，而右端偏序由 \(\mathbf d\mapsto \mathscr L_{\mathbf d}\) 唯一搬运得到。
+
+特别地，在 window-\(6\) 上同时成立
+\[
+B_{\mathrm{full}}^{\mathrm{bin}}(6)=2,
+\]
+\[
+\text{不存在任何有限阿贝尔群上的线性陪集划分，其纤维划分等于 }\Fold_6^{\mathrm{bin}}\text{ 的纤维划分},
+\]
+\[
+\text{在 }U_{21}\subset\RR^{21}\text{ 上，少于 }20=|X_6|-1\text{ 个 Bayes 最优 InfoNCE 标量不可能连续单射恢复有序纤维谱}.
+\]
+因此，window-\(6\) 上至少并存三条互不塌缩的复杂度轴：实例反演复杂度、线性表示复杂度与统计审计复杂度。
+\end{theorem}
+\begin{proof}
+前一组等价正是推论 \ref{cor:conclusion-capacity-majorization-infonce-antiisomorphism} 的内容：在固定 \((S,N)\)-切片上，主序、容量曲线逐点序与完整 Bayes--InfoNCE 塔上的搬运偏序严格一致。window-\(6\) 的三条特化则由推论 \ref{cor:conclusion-window6-inversion-linear-statistical-triple-separation} 直接给出。证毕。
+\end{proof}
+
+\begin{conjecture}[freeze--capacity--audit 支链上的 faithful \texorpdfstring{$\pi$}{pi} 公式三寄存器下界]\label{conj:conclusion-piformula-freezing-capacity-audit-three-register-lower-bound}
+在猜想 \ref{conj:conclusion-foldgauge-pi-three-register-lower-bound} 的语义下，若进一步要求 projective \(\pi\)-通道 faithful 地承载本支链中的冻结前沿、容量全息与统计审计结构，则其外置寄存器至少应裂为如下三类彼此正交的层：
+\[
+\mathfrak R_{\max},
+\qquad
+\mathfrak R_{\mathrm{cap}},
+\qquad
+\mathfrak R_{\mathrm{aud}}.
+\]
+其中
+\begin{enumerate}
+  \item \(\mathfrak R_{\max}\) 负责记录
+  \[
+  (M_m,K_m,M_m^{(2)}),
+  \qquad
+  (\alpha_\ast,g_\ast,\alpha_\ast^{(2)}),
+  \]
+  并据此支配定理 \ref{thm:conclusion-subcritical-budget-single-layer-truncation} 与定理 \ref{thm:conclusion-freezing-measure-collapse-all-axes} 所刻画的单层截断律与冻结相测度塌缩；
+  \item \(\mathfrak R_{\mathrm{cap}}\) 负责记录
+  \[
+  \mathcal C_m^{\mathrm{cont}}(\cdot)
+  \Longleftrightarrow
+  N_m(\cdot)
+  \Longleftrightarrow
+  h_m(\cdot)
+  \Longleftrightarrow
+  A_m,
+  \]
+  并据此支配定理 \ref{thm:conclusion-capacity-wedderburn-thermodynamic-completeness} 中的热力学量、粗粒化可见性与 Wedderburn 块谱；
+  \item \(\mathfrak R_{\mathrm{aud}}\) 负责记录
+  \[
+  \mathrm{Law}(\Pi_{|X_m|}),
+  \qquad
+  h_t(w),
+  \qquad
+  \{L_{K,m}^\star\}_{K=2}^{|X_m|},
+  \]
+  并据此支配定理 \ref{thm:conclusion-sample-pattern-deeptail-top-geometry-completeness}、定理 \ref{thm:conclusion-sample-pattern-family-closes-hot-contact-geometry} 与定理 \ref{thm:conclusion-majorization-capacity-infonce-strict-antiisomorphism} 中的热相接触几何、深尾顶端双参数与统计审计门槛。
+\end{enumerate}
+该猜想断言：\(\mathfrak R_{\max}\) 只见冻结前沿而不见完整 Wedderburn 块谱；\(\mathfrak R_{\mathrm{cap}}\) 给出容量与半单全息，却不自动替代深尾顶端双参数与完整审计塔；\(\mathfrak R_{\mathrm{aud}}\) 虽闭合热相与审计几何，却不压缩为单独的最大纤维寄存器。因而，任何试图把上述三层重新压成单一值层标量接口的 \(\pi\)-公式，都至多在数值层给出局部近似，而不能在本支链上成为 faithful 的 completion 证书。
+\end{conjecture}
+
+\paragraph{统一读法}
+这条链把冻结、容量与审计的接口压成了三种不可互换的完备性。亚极大预算窗的容量缺口只看见最大纤维层；冻结相 escort 测度在全部 Rényi 轴与全变差上一起塌缩到最大层均匀分布；连续容量曲线则把正阶矩谱、尾计数、直方图与 Wedderburn 半单块账本严格锁成同一对象；样本相等模式既恢复有限分辨率上的完整对称接口，又经深尾极点与热相接触公式闭合出顶端几何和热相多重分形几何；而固定总质量切片上的主序、容量与完整 Bayes--InfoNCE 数值塔又构成严格反向同构。于是，在本支链上 faithful 的 \(\pi\)-宿主不能退化为单一标量模型，而必须同时保留冻结寄存器、容量寄存器与审计寄存器三条彼此正交的结构轴。
+
+\endinput

--- a/theory/2026_golden_ratio_driven_scan_projection_generation_recursive_emergence/sections/body/conclusion/subsec__conclusion-hiddenchannel-boundarycarrier-finitejet-schur-median-rigidity.tex
+++ b/theory/2026_golden_ratio_driven_scan_projection_generation_recursive_emergence/sections/body/conclusion/subsec__conclusion-hiddenchannel-boundarycarrier-finitejet-schur-median-rigidity.tex
@@ -1,0 +1,489 @@
+\subsection{隐藏通道熵影、双宿主边界 faithful carrier、有限 jet 刚性与 Schur--median 终端律}\label{subsec:conclusion-hiddenchannel-boundarycarrier-finitejet-schur-median-rigidity}
+
+沿用定理 \ref{thm:conclusion-chebotarev-hiddenchannel-dominant-entropy-barrier}、定理 \ref{thm:conclusion-hidden-artin-ghost-oscillation}、命题 \ref{prop:xi-time-part9g-first-deviation-depth}、定理 \ref{thm:xi-time-part9g-langlands-euler-separation}、定理 \ref{thm:conclusion-boundary-godel-adhesion-defect-phase-diagram}、定理 \ref{thm:conclusion-boundary-godel-bitlength-exponent-equals-adhesion}、定理 \ref{thm:conclusion-prime-log-abel-mellin-pole-rigidity}、推论 \ref{cor:conclusion-prime-log-alpha-singular-rank-one}、定理 \ref{thm:conclusion-prime-log-rh-operator-countable-prime-rank}、定理 \ref{thm:conclusion-hankel-arithmetic-tomography-finite-bad-primes-completion}、定理 \ref{thm:conclusion-hankel-stiffness-dual-role}、定理 \ref{thm:derived-chain-arithmetic-median-unique-minimizer} 与推论 \ref{cor:derived-chain-arithmetic-boolean-interval-geodesics} 的记号。前述结果已经分别给出：primitive Chebotarev 群商熵的隐藏主导障碍与幽灵统计、停机型二进扭子偏离的首次显影深度、subfull regime 中边界复杂度对粘连缺陷的完全塌缩、prime-log 校准的单极点边界方向与可数无限 prime-register 宿主、有限 Hankel realization 的好素数补全与 \(p\)-进刚性，以及有限链内算子的算术中值与布尔测地计数。把这些接口并读后，还可继续压缩为如下七条终端后果。
+
+\begin{theorem}[隐藏主导字符的平方根--平方律]\label{thm:conclusion-hiddenchannel-square-root-square-law}
+设
+\[
+\pi:G_2\twoheadrightarrow G_1,\qquad K:=\ker \pi,
+\]
+并固定 \(u\in(0,1]\)。假设隐藏谱中存在唯一主导字符
+\[
+\chi_\ast\in \widehat G_2\setminus K^\perp
+\]
+及其简单特征值 \(\mu_\ast\)，满足
+\[
+|\mu_\ast|=\eta_{\mathrm{hid}}(u,\pi),
+\]
+且该通道在 \(\mu_\ast\) 处具有谱隙。则存在零均值类函数
+\[
+\varepsilon:G_2\to\CC,
+\qquad
+\pi_\ast\varepsilon=0,
+\]
+以及一条无穷子序列 \(n_j\to\infty\)，使得
+\[
+\Delta_{n_j}
+\asymp
+\frac{n_j^2}{\lambda_1(u)^{2n_j}}
+\bigl|\Pi_{n_j}(\varepsilon;u)\bigr|^2,
+\]
+其中
+\[
+\Pi_n(\varepsilon;u)
+:=
+\sum_{c_2\in G_2}\varepsilon(c_2)\,B_{n,c_2}^{(2)}(u),
+\]
+\[
+\Delta_n
+:=
+D_{\mathrm{KL}}\!\bigl(\mu_{n,u}^{(2)}\Vert u_{G_2}\bigr)
+-
+D_{\mathrm{KL}}\!\bigl(\mu_{n,u}^{(1)}\Vert u_{G_1}\bigr).
+\]
+等价地，在线性统计层，最慢隐藏通道以
+\[
+\Pi_n(\varepsilon;u)\sim c_\varepsilon \mu_\ast^n/n
+\]
+的幽灵振荡存活；而在熵层，同一通道只以平方速率留下阴影：
+\[
+\Delta_n\asymp
+\left(\frac{\eta_{\mathrm{hid}}(u,\pi)}{\lambda_1(u)}\right)^{2n}.
+\]
+故群商熵损失与隐藏幽灵线性统计之间存在严格的平方根--平方对应。
+\end{theorem}
+
+\begin{proof}
+由定理 \ref{thm:conclusion-hidden-artin-ghost-oscillation}，存在零均值类函数 \(\varepsilon\) 与常数 \(c_\varepsilon\neq 0\) 使
+\[
+\Pi_n(\varepsilon;u)
+=
+c_\varepsilon\frac{\mu_\ast^n}{n}
++
+O\!\left(\frac{\eta_-^n}{n}\right),
+\qquad
+\eta_-<\eta_{\mathrm{hid}}(u,\pi).
+\]
+于是沿某条无穷子序列 \(n_j\to\infty\) 有
+\[
+\bigl|\Pi_{n_j}(\varepsilon;u)\bigr|^2
+=
+|c_\varepsilon|^2\eta_{\mathrm{hid}}(u,\pi)^{2n_j}n_j^{-2}(1+o(1)).
+\]
+另一方面，由定理 \ref{thm:conclusion-chebotarev-hiddenchannel-dominant-entropy-barrier}，
+\[
+\Delta_{n_j}
+\asymp
+\left(\frac{\eta_{\mathrm{hid}}(u,\pi)}{\lambda_1(u)}\right)^{2n_j}.
+\]
+将两式比较即得
+\[
+\Delta_{n_j}
+\asymp
+\frac{n_j^2}{\lambda_1(u)^{2n_j}}
+\bigl|\Pi_{n_j}(\varepsilon;u)\bigr|^2.
+\]
+证毕。
+\end{proof}
+
+\begin{theorem}[Walsh 首断点、账本平台与局部因子误差壁垒的刚性锁定]\label{thm:conclusion-halting-walsh-plateau-localfactor-locking}
+设 \(B=2^L\)。对任意图灵机--输入对 \((M,x)\)，定义停机编码
+\[
+\alpha_{M,x}:=\sum_{n\ge 0} t_n(M,x)B^n\in \ZZ_2,
+\]
+并令
+\[
+N\in\NN\cup\{\infty\}
+\]
+为首次停机时间。记 \(k^\ast(M,x)\) 为相应 Walsh 审计中的首个非平凡断点，\((\kappa_m)_{m\ge 0}\) 为账本缺陷剖面，并定义平台起点
+\[
+m_{\mathrm{plat}}(M,x)
+:=
+\inf\{\,m\ge 0:\ \kappa_{m'}=\kappa_m\ \text{对全部 }m'\ge m\,\}.
+\]
+则若 \(N<\infty\)，有精确恒等式
+\[
+m_{\mathrm{plat}}(M,x)=N=\frac{k^\ast(M,x)-1}{L}.
+\]
+并且对任意固定 \(s>0\) 与素数 \(p\)，局部因子误差满足
+\[
+\bigl|L_p(s,g_{M,x})-(1-p^{-s})^{-2}\bigr|
+\le
+C(s,p)\,2^{-N}
+=
+C(s,p)\,2^{-(k^\ast(M,x)-1)/L}.
+\]
+若 \(N=\infty\)，则
+\[
+k^\ast(M,x)=\infty,\qquad
+m_{\mathrm{plat}}(M,x)=\infty,\qquad
+g_{M,x}=I_2,
+\]
+从而局部因子严格退化为平凡模型。
+因此，首次停机时间同时等于二进赋值深度、Walsh 首断点、账本平台起点与局部 Euler 因子接近平凡模型的指数尺度。
+\end{theorem}
+
+\begin{proof}
+由停机型 \(2^L\)-进编码链已经证明的等价关系，
+\[
+N<\infty
+\iff
+\alpha_{M,x}=-B^N
+\iff
+v_2(\alpha_{M,x})=LN
+\iff
+k^\ast(M,x)=LN+1
+\iff
+\kappa_m=\min(m,N)\log 2.
+\]
+故当 \(N<\infty\) 时，\((\kappa_m)\) 的平台恰从 \(m=N\) 开始，即
+\[
+m_{\mathrm{plat}}(M,x)=N=\frac{k^\ast(M,x)-1}{L}.
+\]
+非停机时 \(\alpha_{M,x}=0\)，于是上述四个量都退化到 \(\infty\) 或平凡模型。
+
+另一方面，命题 \ref{prop:xi-time-part9g-first-deviation-depth} 把首次偏离深度精确识别为 \(LN+1\)，而定理 \ref{thm:xi-time-part9g-langlands-euler-separation} 给出停机深度为 \(N\) 时的 Euler 型分离率
+\[
+\bigl|L_p(s,g_{M,x})-(1-p^{-s})^{-2}\bigr|
+\le
+C(s,p)\,4^{-N/2}
+=
+C(s,p)\,2^{-N}.
+\]
+再代入
+\(
+N=(k^\ast(M,x)-1)/L
+\)
+即得所示公式。证毕。
+\end{proof}
+
+\begin{theorem}[边界 faithful carrier 的双宿主分裂]\label{thm:conclusion-boundary-faithful-carriers-double-host-splitting}
+不存在任何有限秩 additive/localized ledger \(H\)，能够同时 faithful 地承载下列两类数据：
+\begin{enumerate}
+  \item 全部 subfull 维 regime \((d_G(A)<n)\) 中的边界复杂度；
+  \item 全部 prime-log 校准边界流 \(\Psi_\alpha\) \((\alpha>0)\) 及其 RH 候选宿主语义。
+\end{enumerate}
+更精确地说，在 \(d_G(A)<n\) 时有
+\[
+d_{\partial G}(A)=\gamma_{\mathrm{adh}}(A),
+\]
+且精确边界 Gödel 码长指数同样等于 \(\gamma_{\mathrm{adh}}(A)\)；另一方面，prime-log 校准链中的 \(\alpha\)-依赖只以一维边界留数
+\[
+c\,\zeta(s)
+\]
+的形式出现，而 faithful 宿主必须满足
+\[
+\ell_{\mathrm{loc}}(M_\alpha)=\aleph_0.
+\]
+于是任何共同 faithful 的最小宿主都必严格分裂为
+\[
+H_{\mathrm{geom}}\oplus H_{\mathrm{arith}},
+\]
+其中 \(H_{\mathrm{geom}}\) 只承载边界 Gödel/粘连缺陷数据，而 \(H_{\mathrm{arith}}\) 必包含可数无限 prime-register 轴。故边界 faithful carrier 的最小原则不是单宿主原则，而是双宿主原则。
+\end{theorem}
+
+\begin{proof}
+在 subfull regime 中，定理 \ref{thm:conclusion-boundary-godel-adhesion-defect-phase-diagram} 给出
+\[
+d_{\partial G}(A)=\gamma_{\mathrm{adh}}(A),
+\]
+而定理 \ref{thm:conclusion-boundary-godel-bitlength-exponent-equals-adhesion} 进一步给出精确边界 Gödel 码位长的指数同样等于 \(\gamma_{\mathrm{adh}}(A)\)。因此，此时几何边界复杂度完全塌缩到粘连缺陷单轴上。
+
+另一方面，定理 \ref{thm:conclusion-prime-log-abel-mellin-pole-rigidity} 给出
+\[
+\mathcal D_\alpha(s)=c\,\zeta(s)+\mathcal J_\alpha(s),
+\]
+其中 \(\mathcal J_\alpha\) 在 \(\Re s>0\) 上全纯；推论 \ref{cor:conclusion-prime-log-alpha-singular-rank-one} 进一步说明 \(\alpha\) 的全部非全纯依赖都被压缩到 \(\CC\cdot \zeta(s)\) 这一维边界方向。最后，由定理 \ref{thm:conclusion-prime-log-rh-operator-countable-prime-rank}，任意 faithful 承载 prime-log 校准的 RH 候选宿主必须满足
+\[
+\ell_{\mathrm{loc}}(M_\alpha)=\aleph_0.
+\]
+故前一类数据要求的是有限几何粘连宿主，而后一类数据要求的是可数无限 prime-register 宿主，二者不可能在同一个有限秩账本中同时 faithful 地闭合。于是最小 faithful carrier 必分裂为几何/算术双宿主。证毕。
+\end{proof}
+
+\begin{theorem}[有限 jet 的 \(p\)-进刚性与 Archimedean 余维一塌缩]\label{thm:conclusion-finitejet-goodprime-archimedean-codimone-collapse}
+在稳定 defect-\(\kappa\) regime 中，固定有限证书
+\[
+T_\kappa:=(u_0,\dots,u_{2\kappa-1};p),
+\]
+其中 \(p\) 为一枚好素数，并满足
+\[
+p\nmid D\det(H_0),\qquad
+H_0:=(u_{i+j})_{0\le i,j\le \kappa-1},
+\qquad
+H_1:=(u_{i+j+1})_{0\le i,j\le \kappa-1}.
+\]
+记
+\[
+A:=H_0^{-1}H_1,\qquad
+\epsilon:=\kappa_{\mathrm{ind}}-S_{\mathrm{def}}.
+\]
+则：
+\begin{enumerate}
+  \item 有限证书 \(T_\kappa\) 唯一决定
+  \[
+  H_0,\ H_1,\ A,\ \{z_j\}_{j=1}^{\kappa},\ \{a_j\}_{j=1}^{\kappa},\ \det P,\ S_{\mathrm{gen}}.
+  \]
+  \item 一切算术模糊性都严格局域于有限坏素数集
+  \[
+  S_{\mathrm{bad}}:=\{p:\ p\mid \det(H_0)\}.
+  \]
+  对任意 \(p\notin S_{\mathrm{bad}}\) 与任意 \(k\ge 1\)，同余系统
+  \[
+  H_0X\equiv H_1 \pmod{p^k}
+  \]
+  有唯一解，且
+  \[
+  X\equiv A \pmod{p^k}.
+  \]
+  \item 在 Archimedean 侧，若定义阈值
+  \[
+  \theta_\epsilon:=4\pi\kappa e^{-1}\epsilon,
+  \]
+  则
+  \[
+  \sigma_j(H_{\kappa-1})\le \theta_\epsilon\qquad (2\le j\le \kappa),
+  \]
+  且
+  \[
+  \sigma_1(H_{\kappa-1})\ge 4\pi S_{\mathrm{def}}-\theta_\epsilon.
+  \]
+  特别地，只要
+  \[
+  \epsilon< \frac{e\,S_{\mathrm{def}}}{2\kappa},
+  \]
+  就有
+  \[
+  \#\{j:\sigma_j(H_{\kappa-1})>\theta_\epsilon\}=1.
+  \]
+\end{enumerate}
+故同一有限 jet 证书同时触发两种互补刚性：在 \(p\)-进方向上，模糊性只剩有限坏素数局域化；在实谱方向上，不确定性被压缩到唯一宏观奇异方向，其余 \(\kappa-1\) 个方向全部线性塌缩。
+\end{theorem}
+
+\begin{proof}
+有限 jet、单个补样与好素数证书的闭包定理已经表明：\(T_\kappa\) 唯一决定 \(H_0,H_1\) 及其伴随 realization 数据 \(A,\{z_j\},\{a_j\},\det P,S_{\mathrm{gen}}\)，这给出第 \(1\) 点。
+
+对第 \(2\) 点，好素数条件意味着 \(H_0\) 在 \(\ZZ_p\) 中可逆。定理 \ref{thm:conclusion-hankel-stiffness-dual-role} 已表明：当 \(p\nmid \det(H_0)\) 时，最小 realization
+\[
+A=H_0^{-1}H_1
+\]
+属于 \(M_\kappa(\ZZ_p)\)，且模 \(p^k\) 数据只能有唯一的 lift；定理 \ref{thm:conclusion-hankel-arithmetic-tomography-finite-bad-primes-completion} 又说明，全部算术失真只能发生在有限坏素数集上。故
+\[
+H_0X\equiv H_1\pmod{p^k}
+\]
+对每个 \(p\notin S_{\mathrm{bad}}\) 都有唯一解，且该解恰为 \(A\) 的模 \(p^k\) 约化。
+
+第 \(3\) 点则是稳定 defect-\(\kappa\) 扇区中已建立的奇异值估计：
+\[
+\sigma_1(H_{\kappa-1})\ge 4\pi S_{\mathrm{def}}-4\pi\kappa e^{-1}\epsilon,
+\qquad
+\sigma_j(H_{\kappa-1})\le 4\pi\kappa e^{-1}\epsilon\quad (j\ge 2).
+\]
+把右端统一记为 \(\theta_\epsilon\) 即得结论。若再有 \(\epsilon<eS_{\mathrm{def}}/(2\kappa)\)，则
+\[
+4\pi S_{\mathrm{def}}-\theta_\epsilon>\theta_\epsilon,
+\]
+故仅第一奇异值超过阈值 \(\theta_\epsilon\)。证毕。
+\end{proof}
+
+\begin{theorem}[均匀权重前沿与精确熵饱和的排斥律]\label{thm:conclusion-defect-uniform-frontier-entropy-saturation-exclusion}
+在稳定 defect-\(\kappa\) regime 中，记
+\[
+\epsilon:=\kappa_{\mathrm{ind}}-S_{\mathrm{def}},
+\qquad
+V_N:=-\log\prod_{j=1}^{\kappa}|\lambda_j^-|,
+\]
+并把缺陷权重写为
+\[
+\{w_\ell\}_{\ell=1}^{\kappa_{\mathrm{ind}}}\subset(0,1),
+\qquad
+\bar w:=\frac{S_{\mathrm{def}}}{\kappa_{\mathrm{ind}}},
+\qquad
+\mathrm{Var}(w):=
+\frac{1}{\kappa_{\mathrm{ind}}}
+\sum_{\ell=1}^{\kappa_{\mathrm{ind}}}(w_\ell-\bar w)^2.
+\]
+则同时成立：
+\begin{enumerate}
+  \item 第一谐波满足 sharp 上界
+  \[
+  |u_1|
+  \le
+  \frac{e}{4\pi}
+  \frac{S_{\mathrm{def}}(\kappa_{\mathrm{ind}}-S_{\mathrm{def}})}{\kappa_{\mathrm{ind}}}
+  -\kappa_{\mathrm{ind}}\mathrm{Var}(w).
+  \]
+  因而在固定 \((\kappa_{\mathrm{ind}},S_{\mathrm{def}})\) 下，\(|u_1|\) 的最大允许值只能由均匀权重
+  \[
+  \mathrm{Var}(w)=0
+  \]
+  实现。
+  \item 负谱体积势满足 blow-up 下界
+  \[
+  V_N\ge (2\kappa-2)\log \epsilon^{-1}-O_{\kappa,S_{\mathrm{def}}}(1)
+  \qquad(\epsilon\downarrow 0).
+  \]
+  \item 若 \(\kappa\ge 2\)，则精确熵饱和
+  \[
+  \kappa_{\mathrm{ind}}=S_{\mathrm{def}}
+  \]
+  不可能发生；事实上这会强制
+  \[
+  u_n=0\quad(n\ge 1),\qquad
+  H_{\kappa-1}=u_0e_0e_0^\top,
+  \]
+  从而
+  \[
+  \rank(H_{\kappa-1})=1,
+  \]
+  与稳定 defect-\(\kappa\) 的秩条件矛盾。
+\end{enumerate}
+因此，稳定多缺陷 regime 的可行区域被两条互补前沿夹住：其上边界是均匀权重极值前沿，其下边界是 \((2\kappa-2)\)-阶体积 blow-up 壁，而精确熵饱和本身被严格排除。
+\end{theorem}
+
+\begin{proof}
+第一条是稳定 defect-\(\kappa\) 口径下的第一谐波方差惩罚上界。其右端在固定 \((\kappa_{\mathrm{ind}},S_{\mathrm{def}})\) 时对 \(\mathrm{Var}(w)\) 严格单调递减，故只有 \(\mathrm{Var}(w)=0\) 的均匀权重才可能实现最大值。
+
+第二条来自负谱乘积上界
+\[
+\prod_{j=1}^{\kappa}|\lambda_j^-|
+\le
+C_{\kappa,S_{\mathrm{def}}}\,\epsilon^{2\kappa-2},
+\]
+取负对数即得
+\[
+V_N\ge (2\kappa-2)\log \epsilon^{-1}-O_{\kappa,S_{\mathrm{def}}}(1).
+\]
+
+对第三条，若 \(\kappa_{\mathrm{ind}}=S_{\mathrm{def}}\)，则已建立的精确熵饱和判据强制全部非零谐波消失，即
+\[
+u_n=0\quad(n\ge 1),
+\]
+于是
+\[
+H_{\kappa-1}=u_0e_0e_0^\top
+\]
+为秩一矩阵。这与稳定 defect-\(\kappa\) regime 要求
+\[
+\rank(H_{\kappa-1})=\kappa\ge 2
+\]
+矛盾。故精确熵饱和不可能发生。证毕。
+\end{proof}
+
+\begin{theorem}[统一分离阈值下 Schur 补账本的指数瓶颈]\label{thm:conclusion-schur-ledger-uniform-separation-exponential-bottleneck}
+设
+\[
+A=\{a_1,\dots,a_\kappa\}\subset \DD
+\]
+为有限缺陷配置，端点 Poisson 权重记为
+\[
+p_j:=P_{a_j}(-1),
+\qquad
+p_\Sigma:=\sum_{j=1}^{\kappa}p_j.
+\]
+令 \((\pi_m)_{m=1}^{\kappa}\) 为相应 Schur 补账本中的步通量，并定义交叉互能
+\[
+E_{\mathrm{int}}
+:=
+2\sum_{1\le j<k\le \kappa}\bigl(-\log \rho(a_j,a_k)\bigr).
+\]
+若存在 \(\rho_0\in(0,1)\) 使
+\[
+\rho(a_j,a_k)\le \rho_0
+\qquad (j\neq k),
+\]
+则存在某个指标 \(m^\ast\in\{1,\dots,\kappa\}\) 使
+\[
+\pi_{m^\ast}\le p_\Sigma\,\rho_0^{\,\kappa-1}.
+\]
+若进一步满足总端点通量的线性控制
+\[
+p_\Sigma\le C\kappa,
+\]
+则可 sharpen 为
+\[
+\pi_{m^\ast}\le C\kappa\,\rho_0^{\,\kappa-1}.
+\]
+因此，在统一伪双曲分离阈值下，Schur 补账本中必然出现一个指数瓶颈步骤；它的压缩率对缺陷数 \(\kappa\) 呈严格指数衰减，而不是仅仅线性恶化。
+\end{theorem}
+
+\begin{proof}
+前述 Pick--Poisson/Schur ledger 链已经证明：存在某个 \(m^\ast\) 使
+\[
+\pi_{m^\ast}\le p_{m^\ast}\exp(-E_{\mathrm{int}}/\kappa).
+\]
+而在统一分离阈值 \(\rho(a_j,a_k)\le \rho_0\) 下，
+\[
+E_{\mathrm{int}}
+=
+2\sum_{1\le j<k\le \kappa}\bigl(-\log \rho(a_j,a_k)\bigr)
+\ge
+2\binom{\kappa}{2}(-\log \rho_0)
+=
+\kappa(\kappa-1)(-\log \rho_0).
+\]
+故
+\[
+\exp(-E_{\mathrm{int}}/\kappa)\le \rho_0^{\,\kappa-1}.
+\]
+再用
+\[
+p_{m^\ast}\le p_\Sigma
+\]
+便得到
+\[
+\pi_{m^\ast}\le p_\Sigma\,\rho_0^{\,\kappa-1}.
+\]
+若再有 \(p_\Sigma\le C\kappa\)，则第二式随之成立。证毕。
+\end{proof}
+
+\begin{theorem}[算术中值的唯一极小性与测地退化的阶乘律]\label{thm:conclusion-chain-arithmetic-median-factorial-geodesics}
+设 \(P\) 为有限链，\(J(P)\) 为其 inner operators 的分配格。取单射素数标号
+\[
+q:P\hookrightarrow\mathbb P,
+\]
+并记平方自由算术嵌入为
+\[
+\Phi_q:J(P)\hookrightarrow \NN_{\mathrm{sf}}.
+\]
+对任意三点 \(I_1,I_2,I_3\in J(P)\)，记
+\[
+n_i:=\Phi_q(I_i),
+\qquad
+I_{123}:=\operatorname{med}_{J(P)}(I_1,I_2,I_3).
+\]
+则：
+\begin{enumerate}
+  \item 算术中值满足闭式
+  \[
+  \Phi_q(I_{123})
+  =
+  \frac{\gcd(n_1,n_2)\gcd(n_2,n_3)\gcd(n_3,n_1)}
+  {\gcd(n_1,n_2,n_3)^2},
+  \]
+  并且在椭圆族 \((\mathcal E,\delta_{\mathcal E})\) 中，\(E_{\Phi_q(I_{123})}\) 是唯一极小化
+  \[
+  E_n\longmapsto
+  \delta_{\mathcal E}(E_n,E_{n_1})
+  +\delta_{\mathcal E}(E_n,E_{n_2})
+  +\delta_{\mathcal E}(E_n,E_{n_3})
+  \]
+  的点。
+  \item 若 \(u,v\in \Phi_q(J(P))\) 满足 \(u\mid v\)，并记
+  \[
+  \operatorname{supp}(v/u)=\{p_1,\dots,p_r\},
+  \]
+  则 divisibility 区间 \([u,v]_{\mid}\) 与 \(r\)-维布尔立方同构，且从 \(u\) 到 \(v\) 的最短 \(\delta_{\mathcal E}\)-测地条数恰为
+  \[
+  r!.
+  \]
+\end{enumerate}
+因此，该 faithful 算术模型中，中值唯一性与测地唯一性严格分离：三点中值只有一个，而端点间最短输运却呈现阶乘级退化。
+\end{theorem}
+
+\begin{proof}
+第 \(1\) 条正是定理 \ref{thm:derived-chain-arithmetic-median-unique-minimizer}：算术中值的闭式由平方自由赋值几何直接给出，而椭圆实现 \(\Psi_q(I)=E_{\Phi_q(I)}\) 保持三元中值与距离，从而把 \(I_{123}\) 送到总距离和的唯一极小点。
+
+第 \(2\) 条则由推论 \ref{cor:derived-chain-arithmetic-boolean-interval-geodesics} 直接给出。对可除区间 \([u,v]_{\mid}\)，支撑差 \(\operatorname{supp}(v/u)=\{p_1,\dots,p_r\}\) 的每个子集都对应一个中间点，故该区间与 \(2^{[r]}\) 同构；而每条最短测地都恰对应于把 \(p_1,\dots,p_r\) 逐个并入的某个排列，故其总数正是 \(r!\)。证毕。
+\end{proof}
+
+综上，这一链条把几类原本分散的有限证书刚性焊接到同一终端图景中：hidden Chebotarev 通道把线性幽灵与 KL 熵影锁成平方根--平方律；停机型 \(2^L\)-进偏离把 Walsh 首断点、账本平台与 Euler 局部因子误差锁成同一有限视界深度；boundary faithful carrier 不能压缩为单宿主，而被迫分裂为几何粘连轴与可数 prime-register 轴；而 stable defect-\(\kappa\) 的有限 jet 证书又同时把 \(p\)-进模糊性压到有限坏素数，把 Archimedean 模糊性压到唯一宏观奇异方向，并在统一分离阈值下强制 Schur 补账本出现指数瓶颈。最后，有限链内算子的平方自由算术实现进一步表明：唯一中值与阶乘级测地退化可以在同一 faithful 模型中并存，从而把“唯一恢复”与“唯一输运”彻底区分开来。

--- a/theory/2026_golden_ratio_driven_scan_projection_generation_recursive_emergence/sections/body/conclusion/subsec__conclusion-moment-determinacy-hankel-goodprime-recovery-discriminant.tex
+++ b/theory/2026_golden_ratio_driven_scan_projection_generation_recursive_emergence/sections/body/conclusion/subsec__conclusion-moment-determinacy-hankel-goodprime-recovery-discriminant.tex
@@ -1,0 +1,432 @@
+\subsection{碰撞矩的最小完备性、Hankel 模素数恢复与分歧主导猜想}\label{subsec:conclusion-moment-determinacy-hankel-goodprime-recovery-discriminant}
+沿用推论 \ref{cor:conclusion-fixedresolution-first-2sm-sufficiency}、
+定理 \ref{thm:conclusion-fixedresolution-principal-hankelnull-finite-determinacy}、
+定理 \ref{thm:conclusion-hankel-primitive-torsion-only-finite-characteristic-distortion}、
+推论 \ref{cor:conclusion-hankel-good-prime-rigidity-finite-distortion-support}、
+定理 \ref{thm:conclusion-resonance-window-hankel-null-principalization}、
+推论 \ref{cor:conclusion-resonance-window-hankel-null-gcd-recovery}、
+定理 \ref{thm:conclusion-resonance-window-mod2-maximal-coroot-discriminant}、
+定理 \ref{thm:pom-mom-symmetric-observables-stone-weierstrass}、
+定理 \ref{thm:pom-max-fiber}、
+推论 \ref{cor:pom-resonance-short-nullmode-certificate}
+与定理 \ref{thm:pom-resonance-disc-3adic-q13-15} 的记号。
+前文已经分别在固定分辨率层证明了碰撞矩对有限纤维谱的 Prony--Hankel 完全重构、连续容量曲线与全矩谱的完备对偶，以及 resonance window 中 Hankel-null 模的主理想化与坏素数有限性。把这些接口进一步合并之后，可得到两条先前尚未在结论区单独封口的结构链：其一，去掉平凡矩 \(S_0,S_1\) 之后，直方图恢复的 exact 统计复杂度仍保持 sharp；其二，有限窗 Hankel 核在好素数上不仅主理想化，而且可经有限素数采样协议精确、半单地重构整系数递推多项式。
+
+\begin{theorem}[固定分辨率直方图的最小完备碰撞统计量]\label{thm:conclusion-fixedresolution-nontrivial-collision-minimal-complete-statistic}
+固定分辨率 \(m\ge 1\)。记纤维多重度的不同取值为
+\[
+1\le \delta_1<\cdots<\delta_{s_m},
+\qquad
+\mu_j:=\#\{x\in X_m:d_m(x)=\delta_j\}.
+\]
+于是
+\[
+S_q(m)=\sum_{x\in X_m}d_m(x)^q=\sum_{j=1}^{s_m}\mu_j\delta_j^q
+\qquad(q\ge 0).
+\]
+则非平凡碰撞矩前缀
+\[
+\mathbf C_m:=
+\bigl(S_2(m),S_3(m),\dots,S_{2s_m-1}(m)\bigr)
+\]
+唯一决定整组直方图数据
+\(
+\{(\delta_j,\mu_j)\}_{j=1}^{s_m}
+\)。
+更强地，在一般 \(s_m\)-原子正整数谱类上，任何更短的前缀
+\[
+\bigl(S_2(m),\dots,S_{2s_m-2}(m)\bigr)
+\]
+都不可能统一地唯一恢复该直方图。
+\end{theorem}
+\begin{proof}
+由推论 \ref{cor:conclusion-fixedresolution-first-2sm-sufficiency}，首 \(2s_m\) 阶矩
+\[
+S_0(m),S_1(m),\dots,S_{2s_m-1}(m)
+\]
+已经唯一决定全部原子 \(\delta_j\) 及其重数 \(\mu_j\)。而在固定分辨率 \(m\) 上，
+\[
+S_0(m)=|X_m|,
+\qquad
+S_1(m)=\sum_{x\in X_m}d_m(x)=2^m
+\]
+是先验常数，故非平凡前缀 \(\mathbf C_m\) 已含全部恢复信息。
+
+另一方面，定理 \ref{thm:pom-fiber-spectrum-finite-reconstruction-sharp} 证明：在一般 \(r\)-原子正整数谱类上，前 \(2r-1\) 个幂和不足以统一唯一恢复全部原子与重数。把 \(r=s_m\) 代入并注意其中 \(k=0,1\) 两级在当前固定分辨率切片上已被常数化，便得：若删去最后一个非平凡矩 \(S_{2s_m-1}(m)\)，则统一唯一性一般失效。证毕。
+\end{proof}
+
+\begin{corollary}[精确统计维数的平方根塌缩律]\label{cor:conclusion-fixedresolution-exact-statistic-dimension-squareroot-collapse}
+定义固定分辨率 \(m\) 处的最小非平凡 exact statistic dimension 为
+\[
+\mathfrak s_m^{\mathrm{ex}}:=2s_m-2.
+\]
+若
+\[
+D_m:=\max_{x\in X_m}d_m(x),
+\]
+则有上界
+\[
+\mathfrak s_m^{\mathrm{ex}}\le 2D_m-2.
+\]
+进一步，由
+\[
+D_{2k}=F_{k+2},
+\qquad
+D_{2k+1}=2F_{k+1},
+\qquad
+|X_m|=F_{m+2},
+\]
+得到
+\[
+\mathfrak s_m^{\mathrm{ex}}=O(\varphi^{m/2})=O(|X_m|^{1/2}),
+\qquad
+\frac{\mathfrak s_m^{\mathrm{ex}}}{|X_m|}\longrightarrow 0.
+\]
+更精确地，
+\[
+\limsup_{k\to\infty}\frac{\mathfrak s_{2k}^{\mathrm{ex}}}{\sqrt{|X_{2k}|}}
+\le
+\frac{2\varphi}{5^{1/4}},
+\qquad
+\limsup_{k\to\infty}\frac{\mathfrak s_{2k+1}^{\mathrm{ex}}}{\sqrt{|X_{2k+1}|}}
+\le
+\frac{4}{\sqrt{\varphi}\,5^{1/4}}.
+\]
+\end{corollary}
+\begin{proof}
+因为纤维重数只能取 \(\{1,\dots,D_m\}\) 中的正整数值，所以
+\[
+s_m\le D_m,
+\]
+从而
+\[
+\mathfrak s_m^{\mathrm{ex}}=2s_m-2\le 2D_m-2.
+\]
+再由定理 \ref{thm:pom-max-fiber} 的闭式
+\[
+D_{2k}=F_{k+2},
+\qquad
+D_{2k+1}=2F_{k+1},
+\]
+以及 \(|X_m|=F_{m+2}\)，结合 Binet 渐近
+\[
+F_n\sim \frac{\varphi^n}{\sqrt5},
+\]
+便得
+\[
+D_m=\Theta(\varphi^{m/2}),
+\qquad
+|X_m|=\Theta(\varphi^m),
+\]
+从而
+\(
+\mathfrak s_m^{\mathrm{ex}}=O(|X_m|^{1/2})
+\)
+与比值极限。把上式分别代入偶、奇分辨率，并除以相应的 \(\sqrt{|X_m|}\) 即得两条 \(\limsup\) 常数。证毕。
+\end{proof}
+
+\begin{theorem}[从 Stone--Weierstrass 稠密生成到有限 exact signature 的塌缩]\label{thm:conclusion-r-atomic-spectrum-exact-signature-collapse}
+设 \(\mathscr H_r\) 为全部 \(r\)-原子正整数谱
+\[
+\sum_{j=1}^{r}\mu_j\delta_j^q
+\qquad
+(1\le \delta_1<\cdots<\delta_r,\ \mu_j\in\ZZ_{>0})
+\]
+所成的类。
+则在交换对称可观测代数的连续环境空间中，定理 \ref{thm:pom-mom-symmetric-observables-stone-weierstrass} 仅给出幂和族 \(\{p_q\}_{q\ge 2}\) 的稠密生成；然而在 \(\mathscr H_r\) 上，有限前缀
+\[
+(S_2,\dots,S_{2r-1})
+\]
+已经构成 exact signature：任意定义在 \(\mathscr H_r\) 上的可观测量都可经该向量的像完全编码。反之，前缀
+\[
+(S_2,\dots,S_{2r-2})
+\]
+不具有这种统一完备性。
+\end{theorem}
+\begin{proof}
+定理 \ref{thm:pom-mom-symmetric-observables-stone-weierstrass} 说明：在连续交换对称观测空间中，幂和族提供的是 Stone--Weierstrass 型一致逼近，而非有限 exact 生成。
+
+另一方面，由定理 \ref{thm:conclusion-fixedresolution-nontrivial-collision-minimal-complete-statistic}，在 \(r\)-原子正整数谱类 \(\mathscr H_r\) 上，映射
+\[
+(\delta_j,\mu_j)_{j=1}^{r}
+\longmapsto
+(S_2,\dots,S_{2r-1})
+\]
+是单射。因此任意可观测量都可经该单射的像唯一编码；而删去最后一个矩后，该单射在一般情形下失效。于是稠密生成在有限原子谱类上塌缩为 exact signature，而这种塌缩的 sharp 阈值正是 \(2r-2\) 个非平凡标量。证毕。
+\end{proof}
+
+\begin{theorem}[好素数上的精确模 \texorpdfstring{$p$}{p} 递推恢复]\label{thm:conclusion-resonance-window-goodprime-exact-modp-recovery}
+固定 \(q\in\{9,\dots,17\}\)，取共振审计中的有限 Hankel 块
+\[
+\mathsf H_{N,L}(q),
+\]
+并记其首一最小递推特征多项式为
+\[
+P_q(\lambda)\in \ZZ[\lambda],
+\qquad
+d_q:=\deg P_q.
+\]
+定义
+\[
+K_{\ZZ}(q):=\ker_{\ZZ}\!\bigl(\mathsf H_{N,L}(q)\bigr),
+\]
+\[
+M_{\ZZ}(P_q):=
+\Bigl\{
+\operatorname{coeff}_{<L}\!\bigl(Q(\lambda)P_q(\lambda)\bigr):
+\deg Q\le L-d_q-1
+\Bigr\},
+\]
+以及原始剩余商
+\[
+T_{\mathrm{prim}}(q):=K_{\ZZ}(q)\big/M_{\ZZ}(P_q).
+\]
+再记秩降素数集
+\[
+\mathcal B_{\mathrm{rk}}(q;N,L):=
+\left\{
+p\ \text{prime}:\ \rank_{\FF_p}\!\bigl(\mathsf H_{N,L}(q)\bmod p\bigr)<d_q
+\right\}.
+\]
+若
+\[
+p\notin
+\mathcal B_{\mathrm{rk}}(q;N,L)
+\cup
+\{\ell:\ \ell\mid |T_{\mathrm{prim}}(q)|\},
+\]
+则有严格等式
+\[
+\ker_{\FF_p}\!\bigl(\mathsf H_{N,L}(q)\bmod p\bigr)
+=
+\mathcal M_L(P_q\bmod p).
+\]
+因此，把该核的任意一组 \(\FF_p\)-基解释为次数 \(<L\) 的多项式，则它们的最大公因子恰为
+\[
+P_q(\lambda)\bmod p
+\]
+（差一个 \(\FF_p^\times\) 标量）。
+\end{theorem}
+\begin{proof}
+由定理 \ref{thm:conclusion-hankel-primitive-torsion-only-finite-characteristic-distortion} 与推论 \ref{cor:conclusion-hankel-good-prime-rigidity-finite-distortion-support}，在排除秩降素数与 \(T_{\mathrm{prim}}(q)\) 的素因子后，模 \(p\) Hankel 核严格退化为最小递推的有限截断倍乘子模，即
+\[
+\ker_{\FF_p}\!\bigl(\mathsf H_{N,L}(q)\bmod p\bigr)
+=
+\mathcal M_L(P_q\bmod p).
+\]
+
+现取该核的一组 \(\FF_p\)-基，并把它们解释为多项式
+\[
+Q_1(\lambda)P_q(\lambda),\dots,Q_s(\lambda)P_q(\lambda)
+\qquad (\bmod p),
+\]
+其中 \(\deg Q_j\le L-d_q-1\)。由于这些向量张成整个 \(\mathcal M_L(P_q\bmod p)\)，常数多项式 \(1\) 必属于 \((Q_1,\dots,Q_s)\) 的 \(\FF_p\)-线性张成。于是
+\[
+\gcd(Q_1,\dots,Q_s)=1
+\qquad (\bmod p),
+\]
+从而
+\[
+\gcd(Q_1P_q,\dots,Q_sP_q)=P_q
+\qquad (\bmod p)
+\]
+（差一个单位因子）。证毕。
+\end{proof}
+
+\begin{corollary}[共振窗的强制分歧素数]\label{cor:conclusion-resonance-window-forced-ramification-primes}
+对全部 \(q\in\{9,\dots,17\}\)，均有
+\[
+2^{d_q-1}\mid \Disc(P_q),
+\]
+故 \(p=2\) 是整个共振窗的普适强制分歧素数。进一步，对 \(q\in\{13,15\}\)，有
+\[
+3^8\mid \Disc(P_q),
+\]
+故 \(p=3\) 是该二点上的额外强制分歧素数。于是：
+\[
+P_q\bmod 2 \text{ 在整个共振窗上均非平方自由},
+\]
+\[
+P_q\bmod 3 \text{ 在 } q=13,15 \text{ 上非平方自由}.
+\]
+换言之，dyadic 非半单性是窗口级的，而 ternary 非半单性是选择性的。
+\end{corollary}
+\begin{proof}
+定理 \ref{thm:conclusion-resonance-window-mod2-maximal-coroot-discriminant} 已给出
+\[
+2^{d_q-1}\mid \Disc(P_q)
+\qquad(q=9,\dots,17),
+\]
+而定理 \ref{thm:pom-resonance-disc-3adic-q13-15} 给出
+\[
+3^8\mid \Disc(P_q)
+\qquad(q=13,15).
+\]
+对首一整数多项式而言，只要 \(p\mid \Disc(P_q)\)，则
+\[
+\gcd(P_q\bmod p,\ (P_q\bmod p)')\neq 1,
+\]
+故 \(P_q\bmod p\) 非平方自由。将 \(p=2\) 与 \(p=3\) 的两组整除式分别代入，便得结论。证毕。
+\end{proof}
+
+\begin{theorem}[无穷多完全可审计素数]\label{thm:conclusion-resonance-window-infinitely-many-fully-auditable-primes}
+在定理 \ref{thm:conclusion-resonance-window-goodprime-exact-modp-recovery} 的设定下，定义
+\[
+\mathcal A_q(N,L):=
+\left\{
+p\ \text{prime}:
+p\notin
+\mathcal B_{\mathrm{rk}}(q;N,L)
+\cup
+\{\ell:\ell\mid |T_{\mathrm{prim}}(q)|\}
+\cup
+\{p:p\mid \Disc(P_q)\}
+\right\}.
+\]
+则 \(\mathcal A_q(N,L)\) 为无穷集合。并且对每个 \(p\in\mathcal A_q(N,L)\)，同时成立：
+\begin{enumerate}
+  \item 模 \(p\) 的 Hankel 核精确等于主理想核：
+  \[
+  \ker_{\FF_p}\!\bigl(\mathsf H_{N,L}(q)\bmod p\bigr)
+  =
+  \mathcal M_L(P_q\bmod p);
+  \]
+  \item \(P_q\bmod p\) 平方自由；
+  \item 因而 \(P_q\bmod p\) 可由任意模 \(p\) 核基的最大公因子精确且半单地恢复。
+\end{enumerate}
+\end{theorem}
+\begin{proof}
+由推论 \ref{cor:conclusion-hankel-good-prime-rigidity-finite-distortion-support}，
+\[
+\mathcal B_{\mathrm{rk}}(q;N,L)
+\cup
+\{\ell:\ell\mid |T_{\mathrm{prim}}(q)|\}
+\]
+是有限集；另一方面，\(\Disc(P_q)\neq 0\) 只含有限多个素因子，故其素因子集合亦有限。于是 \(\mathcal A_q(N,L)\) 是素数集合中去掉有限集后的补集，因此无穷。
+
+若 \(p\in\mathcal A_q(N,L)\)，则首先由定理 \ref{thm:conclusion-resonance-window-goodprime-exact-modp-recovery} 得到主理想核等式。其次，由 \(p\nmid\Disc(P_q)\) 可知 \(P_q\bmod p\) 平方自由。最后，平方自由性与主理想核等式合并后，任意核基的最大公因子便给出 \(P_q\bmod p\) 的精确半单恢复。证毕。
+\end{proof}
+
+\begin{theorem}[有限素数采样的 exact recurrence recovery 协议]\label{thm:conclusion-resonance-window-finite-prime-sampling-exact-recovery}
+沿用定理 \ref{thm:conclusion-resonance-window-infinitely-many-fully-auditable-primes} 的记号。若已知一个先验高度界
+\[
+H_q\ge \max_{0\le j\le d_q-1}|c_j|,
+\qquad
+P_q(\lambda)=\lambda^{d_q}+c_{d_q-1}\lambda^{d_q-1}+\cdots+c_0,
+\]
+并取若干素数
+\[
+p_1,\dots,p_s\in \mathcal A_q(N,L)
+\]
+使
+\[
+M:=\prod_{i=1}^{s}p_i>2H_q,
+\]
+则由模 \(p_i\) 的核基最大公因子恢复出的多项式 \(P_q\bmod p_i\)，经中国剩余定理与平衡提升，可唯一重构完整的整数多项式 \(P_q\)。
+\end{theorem}
+\begin{proof}
+由定理 \ref{thm:conclusion-resonance-window-infinitely-many-fully-auditable-primes}，每个 \(p_i\) 都给出正确的 \(P_q\bmod p_i\)。因此每个系数 \(c_j\) 在模
+\[
+M=\prod_{i=1}^{s}p_i
+\]
+下已知。又因为 \(|c_j|\le H_q<M/2\)，所以其平衡剩余代表在区间 \((-M/2,M/2)\) 中唯一。于是所有系数 \(c_j\) 均可唯一提升为整数，从而首一整系数多项式 \(P_q\) 被唯一恢复。证毕。
+\end{proof}
+
+\begin{theorem}[共振窗整数 NullMode 证书的一致短度]\label{thm:conclusion-resonance-window-uniform-short-nullmode-certificates}
+对 \(q=9,\dots,17\)，设共振审计使用的名义 Hankel 宽度为
+\[
+n=2\Bigl\lfloor\frac q2\Bigr\rfloor+1,
+\]
+并令
+\[
+\Delta(q):=n-d_q.
+\]
+若 \(\Delta(q)>0\)，则存在非零整数证书
+\[
+\alpha\in \mathrm{NullModes}(q)\subset \ZZ^n
+\]
+满足统一界
+\[
+\|\alpha\|_\infty\le (2nB_q)^{13/2},
+\qquad
+B_q:=\max_{0\le i\le L-1,\ 0\le j\le n-1}a_{i+j},
+\qquad
+a_t=S_q(t+2).
+\]
+因此，在整个已审计共振窗中，整数 Hankel-null 证书的位长满足
+\[
+\log \|\alpha\|_\infty = O\!\bigl(\log(nB_q)\bigr),
+\]
+并且该指数常数对全部 \(q=9,\dots,17\) 统一。
+\end{theorem}
+\begin{proof}
+由推论 \ref{cor:pom-resonance-short-nullmode-certificate}，若 \(\Delta(q)>0\)，则存在非零
+\(
+\alpha\in\mathrm{NullModes}(q)
+\)
+满足
+\[
+\|\alpha\|_\infty\le (2nB_q)^{d_q/(n-d_q)}.
+\]
+在当前已审计共振窗中，次数列与名义宽度列分别为
+\[
+(d_q)_{q=9}^{17}=(7,9,9,13,11,13,11,13,13),
+\]
+\[
+(n)_{q=9}^{17}=(9,11,11,13,13,15,15,17,17).
+\]
+对所有满足 \(\Delta(q)>0\) 的 \(q\)，直接比较可得
+\[
+\frac{d_q}{n-d_q}\le \frac{13}{2},
+\]
+并在 \(q=14\) 处达到该上界。将此代回上式，即得统一估计
+\[
+\|\alpha\|_\infty\le (2nB_q)^{13/2}.
+\]
+对数化后便得到统一位长界。证毕。
+\end{proof}
+
+\begin{conjecture}[分歧即失真原理]\label{conj:conclusion-resonance-window-ramification-equals-distortion}
+对每个整数 \(q\ge 2\)，应存在充分大的有限 Hankel 审计窗口 \((N,L)\)，使得其全部模素数失真集合恰等于最小递推特征多项式的分歧集合：
+\[
+\mathcal B_{\mathrm{rk}}(q;N,L)
+\cup
+\{\ell:\ell\mid |T_{\mathrm{prim}}(q)|\}
+=
+\{p:\ p\mid \Disc(P_q)\}.
+\]
+等价地，所有模素数审计中的异常方向，最终都由 \(P_q\) 的算术分歧完全解释；不存在真正额外的“截断型坏素数”。
+\end{conjecture}
+
+这条 moment/Hankel 链可压缩为
+\[
+\boxed{
+\text{固定分辨率的非平凡碰撞矩前缀}
+\Longrightarrow
+\text{最小完备直方图签名}
+\Longrightarrow
+\text{exact statistic dimension 的平方根塌缩}
+}
+\]
+\[
+\boxed{
+\text{有限窗 Hankel 主理想刚性}
+\Longrightarrow
+\text{好素数上的 exact 模 }p\text{ 恢复}
+\Longrightarrow
+\text{无穷多完全可审计素数}
+\Longrightarrow
+\text{有限素数采样重构 }P_q
+}
+\]
+\[
+\boxed{
+\text{dyadic/triadic 分歧强制}
+\Longrightarrow
+\text{窗口级坏素数支撑}
+\Longrightarrow
+\text{分歧是否已解释全部失真}
+}.
+\]
+因此，在这一分支中，moment determinacy 不再只是固定尺度上的有限重构，而是与 Hankel 模素数恢复、坏素数有限性与分歧算术共同闭合为一条可执行的谱恢复协议。
+

--- a/theory/2026_golden_ratio_driven_scan_projection_generation_recursive_emergence/sections/body/conclusion/subsec__conclusion-phase-gram-mellin-hardy-radial-rigidity.tex
+++ b/theory/2026_golden_ratio_driven_scan_projection_generation_recursive_emergence/sections/body/conclusion/subsec__conclusion-phase-gram-mellin-hardy-radial-rigidity.tex
@@ -1,0 +1,258 @@
+\subsection{有限 Hardy 证书、有理主弧 Gram 核与 phase Fourier--Mellin 双轴刚性}\label{subsec:conclusion-phase-gram-mellin-hardy-radial-rigidity}
+沿用 circle-dimension phase-gate 一章关于有限模态 Hardy 投影、有理主弧 Gram 核、双底去周期化、尺度 Mellin 叠加完成化、Mellin--Plancherel 幺正切片与连续横截方向唯一性的记号。前文已经分别证明：有限模态相位投影可由显式有理核完全实现；主弧 Gram 二次型的谱贡献可被严格局域化到低频 Ramanujan 相关带；一次尺度上的谱降会通过尺度自举传播为全尺度幂次衰减，且统一谱隙的失败必先出现在有限检查集；两条对数不可公度尺度已足以摧毁单尺度强制的严格虚周期；尺度 Mellin 叠加在保持函数方程与临界线实值性的同时允许连续底混合；最后，unweighted 的等距 Mellin 读出只能落在临界线，而纯相位制度中唯一允许的连续横截方向只能是径向寄存器。把这些接口进一步并读后，可压出如下 phase Fourier--Mellin 闭链。
+
+\begin{proposition}[有限模态 Hardy 证书的有理再生性]\label{prop:conclusion-finite-mode-hardy-rational-reproducibility}
+令
+\[
+w(x):=\frac{1+\mathrm{i}x}{1-\mathrm{i}x},
+\]
+并令
+\[
+\Pi_N:L^2(\RR,\dd\mu)\to \mathrm{Span}\{w(\cdot)^k:0\le k\le N-1\}
+\]
+为前 \(N\) 个非负模态的 Hardy 正交投影。则 \(\Pi_N\) 由显式有理核
+\[
+K_N(x,y)
+=
+\sum_{k=0}^{N-1}w(x)^k\overline{w(y)}^{\,k}
+=
+\frac{1-\bigl(w(x)\overline{w(y)}\bigr)^N}{1-w(x)\overline{w(y)}}
+\]
+唯一表示；并且当 \(x\neq y\) 时有分母闭式化简
+\[
+\frac{1}{1-w(x)\overline{w(y)}}
+=
+\frac12+\frac{1+xy}{2\mathrm{i}(y-x)}.
+\]
+因此，每一个有限模态 Hardy 证书都同时满足：
+\begin{enumerate}
+  \item \(\operatorname{rank}\Pi_N=N\)；
+  \item 投影核完全由有理函数给出；
+  \item 全部非平凡奇性都被压缩到单一 Cauchy 型分母上，而不分散到高模态尾部。
+\end{enumerate}
+\end{proposition}
+\begin{proof}
+命题 \ref{prop:unit-circle-phase-hardy-kernel-rational} 已给出核公式
+\eqref{eq:unit-circle-phase-hardy-kernel}、分母化简
+\eqref{eq:unit-circle-phase-hardy-kernel-denominator} 以及积分算子表示
+\[
+(\Pi_N f)(x)=\int_{\RR}K_N(x,y)f(y)\,\dd\mu(y).
+\]
+由于 \(\Pi_N\) 是到 \(N\)-维模态子空间的正交投影，故 \(\operatorname{rank}\Pi_N=N\)。核表示中的有限几何级数与分母闭式说明其全部信息都落在显式有理表达式中，而非平凡奇性又只由 \((y-x)^{-1}\) 这一单一 Cauchy 通道承载。证毕。
+\end{proof}
+
+\begin{theorem}[主弧 Gram 核的 Ramanujan 局域化]\label{thm:conclusion-majorarc-gram-ramanujan-localization}
+记
+\[
+Q_M:=\left\{\frac aq:1\le q\le M,\ (a,q)=1\right\}\subset \QQ/\ZZ,
+\qquad
+\ell^2(Q_M)\cong \bigoplus_{q\le M}\ell^2\bigl((\ZZ/q\ZZ)^\times\bigr).
+\]
+取一个实偶、非负、快速衰减核 \(\widehat\psi\)，令 \(\psi_L\) 为其 \(L\)-尺度周期化核，并记相应主弧 Gram 算子为 \(K_{M,L}\)。则对任意 \(g\in\ell^2(Q_M)\) 都有严格恒等式
+\[
+\langle g,K_{M,L}g\rangle
+=
+\sum_{n\in\ZZ}\widehat\psi(n/L)
+\left|
+\sum_{q\le M}\ \sum_{(a,q)=1}g(a/q)e^{2\pi\mathrm{i}an/q}
+\right|^2.
+\]
+因此，\(\|K_{M,L}\|_{\mathrm{op}}\) 的主要贡献被完全压缩到一条低频 Ramanujan 相关带中；尤其当 \(g\) 在每个分母层上近常数时，内层和退化为 Ramanujan 和 \(c_q(n)\)，从而整个谱范数问题下降为有限分母层的低频相关审计。
+\end{theorem}
+\begin{proof}
+这正是命题 \ref{prop:conclusion66-gram-ramanujan-decomposition} 的幅度平方恒等式。其右端按频率 \(n\) 精确分解为非负平方振幅，因此谱范数主贡献不可能隐藏在某种连续尾部，而必然由有限分母层与有限低频带之间的相关结构承载。若 \(g\) 在每个分母层上为常数，则内层和直接退化为 Ramanujan 和 \(c_q(n)\)，故问题完全下降为算术相关审计。证毕。
+\end{proof}
+
+\begin{theorem}[有限算术证书对全尺度谱隙的完备控制]\label{thm:conclusion-finite-arithmetic-certificates-control-fullscale-gap}
+在定理 \ref{thm:conclusion-majorarc-gram-ramanujan-localization} 的框架下，取标度关系 \(L\asymp M^2\)。若存在某个尺度 \(M_0\) 使
+\[
+\|K_{M_0,L_0}\|_{\mathrm{op}}\le M_0^{-\eta}
+\qquad
+(\eta>0,\ L_0\asymp M_0^2),
+\]
+则存在 \(\eta'>0\) 使对所有充分大的 \(M\) 及 \(L\asymp M^2\) 都有
+\[
+\|K_{M,L}\|_{\mathrm{op}}\ll M^{-\eta'}.
+\]
+反之，若全尺度统一谱隙失败，则必在一个有限可枚举检查集
+\[
+\mathcal C\subset (0,2\pi)\times \NN
+\]
+中出现可复核反例。因而主弧 Gram 核的全尺度谱隙不是无限验证问题，而是一个有限算术证书问题。
+\end{theorem}
+\begin{proof}
+定理 \ref{thm:conclusion67-scale-bootstrap} 已表明：在 \(L\asymp M^2\) 标度下，一次尺度上的谱降会自举为全尺度的幂次衰减。另一方面，定理 \ref{thm:conclusion68-finite-verification} 已把统一扭曲谱隙等价归约为有限检查集上的核验。将这两条与定理 \ref{thm:conclusion-majorarc-gram-ramanujan-localization} 的 Ramanujan 局域化恒等式并置，便得到所述结论：一次多项式节省会传播到全尺度，而任何统一谱隙的失败都不可能藏在无限远尺度中，而必先在某个有限检查对上显影。证毕。
+\end{proof}
+
+\begin{theorem}[两尺度去周期化的最小性]\label{thm:conclusion-two-incommensurable-scales-minimal-deperiodization}
+设 \(L_1,L_2>1\)，并令
+\[
+f(s):=g(L_1^{-s})+h(L_2^{-s}),
+\]
+其中 \(g,h\) 不具有任何非平凡单位根乘法不变性。若
+\[
+\frac{\log L_1}{\log L_2}\notin\QQ,
+\]
+则 \(f\) 不存在任何非零纯虚周期。反之，单一尺度族
+\[
+s\longmapsto g(L^{-s})
+\]
+必携带严格虚周期梳齿。
+因此，两条不可公度尺度正是摧毁严格虚周期的最小机制。
+\end{theorem}
+\begin{proof}
+正向断言即定理 \ref{thm:xi-two-base-deperiodization-no-imag-period}。反向断言则由命题 \ref{prop:single-scale-dirichlet-imag-period} 给出：单尺度 Dirichlet 化总是具有严格虚周期
+\[
+T_L=\frac{2\pi\mathrm{i}}{\log L}.
+\]
+因此，少于两条不可公度尺度时，竖向周期性无法被摧毁；而一旦引入两条对数不可公度尺度，则任何非零纯虚周期都被禁止。证毕。
+\end{proof}
+
+\begin{theorem}[对称去周期化与函数方程保持的可积完备性]\label{thm:conclusion-scale-mellin-deperiodization-preserves-selfdual-reality}
+在定理 \ref{thm:conclusion-two-incommensurable-scales-minimal-deperiodization} 的双尺度极小去周期机制之上，令 \(w\) 为实值权函数，并定义尺度 Mellin 叠加完成化
+\[
+\mathcal X_{\Delta,w}(s)
+:=
+\int_1^\infty w(\log L)\,\Xi_{\Delta,L}(s)\,\frac{\dd L}{L}.
+\]
+则：
+\begin{enumerate}
+  \item \(\mathcal X_{\Delta,w}\) 保持与单尺度完成化相同的自对偶函数方程
+  \[
+  \mathcal X_{\Delta,w}(s)=\mathcal X_{\Delta,w}(1-s);
+  \]
+  \item 在临界线 \(\Re(s)=\frac12\) 上保持实值性
+  \[
+  \mathcal X_{\Delta,w}\!\left(\frac12+\mathrm{i}t\right)\in\RR;
+  \]
+  \item 因而，双尺度去周期化与连续底混合并不破坏“自对偶--临界线实值”制度。
+\end{enumerate}
+\end{theorem}
+\begin{proof}
+命题 \ref{prop:xi-scale-mellin-fe-real} 已给出尺度 Mellin 叠加完成化的函数方程与临界线实值性。故连续底混合并不以牺牲自对偶结构为代价，而是在保持该对称制度的前提下引入去周期化所需的连续尺度自由度。证毕。
+\end{proof}
+
+\begin{theorem}[临界线的等距唯一性]\label{thm:conclusion-critical-line-unique-unweighted-isometric-slice}
+定义 Mellin 变换
+\[
+(\mathcal M f)(s):=\int_0^\infty f(x)\,x^{s-\frac12}\,\dd^\times x,
+\qquad
+\dd^\times x=\frac{\dd x}{x},
+\]
+并记
+\[
+(\mathcal M_\sigma f)(t):=(\mathcal M f)(\sigma+\mathrm{i}t).
+\]
+则：
+\begin{enumerate}
+  \item 切片
+  \[
+  \mathcal M_{1/2}:L^2_\times\to L^2\!\left(\RR,\frac{\dd t}{2\pi}\right)
+  \]
+  是幺正同构；
+  \item 对任意 \(\sigma\in\RR\)，都有严格权重扭曲恒等式
+  \[
+  \|\mathcal M_\sigma f\|_{L^2(\dd t/2\pi)}
+  =
+  \|x^{\sigma-\frac12}f\|_{L^2_\times};
+  \]
+  \item 因而，唯一不需要额外权重寄存器的等距切片恰是
+  \[
+  \Re(s)=\frac12.
+  \]
+\end{enumerate}
+\end{theorem}
+\begin{proof}
+这正是定理 \ref{thm:mellin-unitary-slice-unique} 的内容。第一条给出 \(\sigma=\frac12\) 时的幺正性；第二条说明所有其它切片都必须引入额外权重 \(x^{\sigma-\frac12}\)。因此，若坚持“不外置任何额外权重记录轴”，则唯一允许的等距读出切片只能是临界线 \(\Re(s)=\frac12\)。证毕。
+\end{proof}
+
+\begin{theorem}[连续横截方向的唯一性]\label{thm:conclusion-radial-axis-unique-continuous-transverse-direction}
+设纯相位读出为
+\[
+u\longmapsto \operatorname{proj}_{\mathsf{Phase}}(u).
+\]
+若允许外置一个连续记录轴 \(r\) 使
+\[
+u\longmapsto \bigl(\operatorname{proj}_{\mathsf{Phase}}(u),r(u)\bigr)
+\]
+成为单射，则任意这样的连续记录轴都必经由 \(|u|\) 因子化；等价地，它与径向寄存器
+\[
+\varrho(u):=\log|u|
+\]
+仅差单调重参数化。
+因此，在纯相位制度中，相位轴之外唯一允许的连续横截方向就是径向轴。
+\end{theorem}
+\begin{proof}
+这正是推论 \ref{cor:xi-unique-continuous-transverse-register} 的内容：任何使纯相位读出单射化的连续记录轴都必因子化经由 \(|u|\)，从而与 \(\varrho(u)=\log|u|\) 只差一个连续单调重参数化。证毕。
+\end{proof}
+
+\begin{corollary}[相位--径向二轴的范畴刚性]\label{cor:conclusion-phase-radial-two-axis-categorical-rigidity}
+由定理 \ref{thm:conclusion-critical-line-unique-unweighted-isometric-slice} 与定理 \ref{thm:conclusion-radial-axis-unique-continuous-transverse-direction} 可知：
+\begin{enumerate}
+  \item 唯一的内生等距读出方向是临界线切片 \(\Re(s)=\frac12\)；
+  \item 唯一的可外置连续横截方向是径向寄存器 \(\varrho(u)=\log|u|\)；
+  \item 因而，任何同时保持自对偶、临界线实值与扩展保存的连续制度，都必然分裂为
+  \[
+  \boxed{
+  \text{临界线上的幺正相位读出}
+  \;\oplus\;
+  \text{径向记录轴}
+  }.
+  \]
+\end{enumerate}
+\end{corollary}
+\begin{proof}
+第一点由定理 \ref{thm:conclusion-critical-line-unique-unweighted-isometric-slice}；第二点由定理 \ref{thm:conclusion-radial-axis-unique-continuous-transverse-direction}；第三点是二者的直接合并。证毕。
+\end{proof}
+
+\begin{theorem}[phase Fourier--Mellin 闭链]\label{thm:conclusion-phase-fourier-mellin-closed-chain}
+第 \(12.26\) 至 \(12.41\) 节所蕴含的有限与连续结构可被压缩为一条严格闭合链：
+\[
+\boxed{
+\text{有限模态 Hardy 投影}
+\Longrightarrow
+\text{有理主弧 Gram 核}
+\Longrightarrow
+\text{单尺度谱降的全尺度传播}
+\Longrightarrow
+\text{有限算术证书的完备控制}
+\Longrightarrow
+\text{最小两尺度去周期化}
+\Longrightarrow
+\text{连续底 Mellin 完成化}
+\Longrightarrow
+\text{临界线等距唯一性}
+\Longrightarrow
+\text{径向横截唯一性}.
+}
+\]
+更准确地说：
+\begin{enumerate}
+  \item 有限模态截断由显式有理核 \(K_N(x,y)\) 完全实现，故连续对象已在有限秩层被代数化；
+  \item 主弧 Gram 核把谱范数问题严格局域化为有限分母层的 Ramanujan 相关和；
+  \item 一次尺度上的谱降经尺度自举立刻传播到全尺度，而统一谱隙又可由有限检查集完全判定；
+  \item 双底不可公度叠加是摧毁严格虚周期的最小机制；
+  \item 尺度 Mellin 叠加完成化保持函数方程与临界线实值性；
+  \item Mellin--Plancherel 唯一性把“无外置权重的等距读出”唯一钉在临界线；
+  \item 扩展保存制度又把唯一连续横截方向钉在径向轴上。
+\end{enumerate}
+因此，这一段落中的有限核、Ramanujan 相关、Mellin 完成与记录轴并非几套平行字典，而是已经内生闭合成一条新的刚性链：
+\[
+\boxed{
+\text{算术有限证书}
+\Longrightarrow
+\text{连续核谱}
+\Longrightarrow
+\text{最小去周期化}
+\Longrightarrow
+\text{临界线唯一性}
+\Longrightarrow
+\text{径向轴唯一性}.
+}
+\]
+\end{theorem}
+\begin{proof}
+逐条应用命题 \ref{prop:conclusion-finite-mode-hardy-rational-reproducibility}、定理 \ref{thm:conclusion-majorarc-gram-ramanujan-localization}、定理 \ref{thm:conclusion-finite-arithmetic-certificates-control-fullscale-gap}、定理 \ref{thm:conclusion-two-incommensurable-scales-minimal-deperiodization}、定理 \ref{thm:conclusion-scale-mellin-deperiodization-preserves-selfdual-reality}、定理 \ref{thm:conclusion-critical-line-unique-unweighted-isometric-slice}、定理 \ref{thm:conclusion-radial-axis-unique-continuous-transverse-direction} 及推论 \ref{cor:conclusion-phase-radial-two-axis-categorical-rigidity} 即得。证毕。
+\end{proof}
+
+\endinput

--- a/theory/2026_golden_ratio_driven_scan_projection_generation_recursive_emergence/sections/body/conclusion/subsec__conclusion-prime-register-ramanujan-shadow-budget-localization-blindness.tex
+++ b/theory/2026_golden_ratio_driven_scan_projection_generation_recursive_emergence/sections/body/conclusion/subsec__conclusion-prime-register-ramanujan-shadow-budget-localization-blindness.tex
@@ -1,0 +1,251 @@
+\subsection{prime-register stage 的 Ramanujan 阴影、预算编译与有限导子盲性}\label{subsec:conclusion-prime-register-ramanujan-shadow-budget-localization-blindness}
+沿用定理 \ref{thm:conclusion-boundary-finite-prime-selector-product-law}、定理 \ref{thm:conclusion-finite-prime-solenoid-terminal-object}、定理 \ref{thm:conclusion-finite-prime-localization-pontryagin-rigidity}、定理 \ref{thm:conclusion-boundary-prime-tail-blindness} 与定理 \ref{thm:conclusion-smith-pprimary-ramanujan-cutoff-completeness} 的记号。此前结论已经分别给出：有限素数联合读出的最小离散寄存规模与最小比特预算、有限素局部化对偶的短正合列及其素支撑可恢复性、有限维连续相位通道对 prime-tail 的结构性失明，以及 Smith \(p\)-主谱的 Ramanujan cutoff 现象。把这些接口限制到单个有限 stage 模
+\[
+M_{S,\boldsymbol\ell}:=\prod_{p\in S}p^{\ell_p}
+\]
+后，还可抽出一条更尖锐的算术闭链：prime-register 的逐层深度、联合预算、局部化对偶核与有限导子盲区都可由同一族 prime-power Ramanujan 阴影统一读出。
+
+\begin{theorem}[prime-register stage 的 Ramanujan 逐层判别]\label{thm:conclusion-prime-register-stage-ramanujan-layer-detection}
+设 \(S\subset \mathbb P\) 为有限素数集，
+\[
+\boldsymbol\ell=(\ell_p)_{p\in S}\in \ZZ_{\ge 1}^{S},
+\qquad
+M_{S,\boldsymbol\ell}:=\prod_{p\in S}p^{\ell_p}.
+\]
+对 \(p\notin S\) 约定 \(\ell_p:=0\)，并定义
+\[
+\mathcal A_{S,\boldsymbol\ell}(q):=c_q(M_{S,\boldsymbol\ell}),
+\qquad
+\mathcal A_{S,\boldsymbol\ell}(1)=c_1(M_{S,\boldsymbol\ell})=1.
+\]
+则对任意素数 \(p\) 与任意 \(k\ge 1\)，成立精确恒等式
+\[
+\mathbf 1_{\{k\le \ell_p\}}
+=
+\frac{1}{p^k}\sum_{j=0}^{k}\mathcal A_{S,\boldsymbol\ell}(p^j).
+\]
+特别地，对每个 \(p\in S\)，有
+\[
+\ell_p
+=
+\max\left\{
+k\ge 1:
+\sum_{j=0}^{k}\mathcal A_{S,\boldsymbol\ell}(p^j)=p^k
+\right\}.
+\]
+因此，prime-register 的每一层深度 \(\ell_p\) 都可由单变量 Ramanujan 素数幂阴影逐层、精确且可逆地恢复。
+\end{theorem}
+\begin{proof}
+对任意整数 \(n\) 与任意 \(k\ge 1\)，经典 Ramanujan 除数恒等式给出
+\[
+\sum_{d\mid p^k}c_d(n)=p^k\,\mathbf 1_{\{p^k\mid n\}}.
+\]
+取 \(n=M_{S,\boldsymbol\ell}\)，并注意 \(p^k\) 的全部正因子恰为 \(p^0,p^1,\dots,p^k\)，即得
+\[
+\sum_{j=0}^{k}\mathcal A_{S,\boldsymbol\ell}(p^j)
+=
+p^k\,\mathbf 1_{\{p^k\mid M_{S,\boldsymbol\ell}\}}
+=
+p^k\,\mathbf 1_{\{k\le \ell_p\}},
+\]
+其中最后一个等价正是 \(v_p(M_{S,\boldsymbol\ell})=\ell_p\)。两边同除以 \(p^k\) 即得第一式。
+
+若 \(p\in S\)，则满足
+\[
+\sum_{j=0}^{k}\mathcal A_{S,\boldsymbol\ell}(p^j)=p^k
+\]
+的最大 \(k\) 恰为 \(\ell_p\)，从而得到第二式。证毕。
+\end{proof}
+
+\begin{theorem}[prime-power Ramanujan 审计的精确 cutoff]\label{thm:conclusion-prime-register-stage-ramanujan-exact-cutoff}
+固定 \(p\in S\)。则截断前缀
+\[
+\bigl(
+\mathcal A_{S,\boldsymbol\ell}(p),
+\mathcal A_{S,\boldsymbol\ell}(p^2),
+\dots,
+\mathcal A_{S,\boldsymbol\ell}(p^K)
+\bigr)
+\]
+唯一决定 \(\ell_p\) 当且仅当
+\[
+K\ge \ell_p+1.
+\]
+换言之，prime-register 的最短充分前缀不是 \(\ell_p\)，而是 \(\ell_p+1\)；额外的一步恰是证实平台终止所必需的熄灯位。
+\end{theorem}
+\begin{proof}
+若 \(K\ge \ell_p+1\)，则由定理 \ref{thm:conclusion-prime-register-stage-ramanujan-layer-detection}，对每个 \(1\le k\le K\) 都可由前缀数据计算
+\[
+\mathbf 1_{\{k\le \ell_p\}}
+=
+\frac{1}{p^k}\left(
+1+\sum_{j=1}^{k}\mathcal A_{S,\boldsymbol\ell}(p^j)
+\right).
+\]
+于是最后一个取值为 \(1\) 的 \(k\) 恰为 \(\ell_p\)。
+
+反之，若 \(K\le \ell_p\)，则对任意整数 \(\ell_p'\ge K\)，在所有 \(1\le j\le K\) 上都有
+\[
+v_p\!\left(p^{\ell_p}\right)\ge j,
+\qquad
+v_p\!\left(p^{\ell_p'}\right)\ge j,
+\]
+故由素数幂 Ramanujan 和的标准公式
+\[
+c_{p^j}(p^a)=p^{j-1}(p-1)
+\qquad (a\ge j)
+\]
+可知
+\[
+c_{p^j}(p^{\ell_p})=c_{p^j}(p^{\ell_p'})
+\qquad (1\le j\le K).
+\]
+因此长度 \(K\) 的截断前缀无法区分 \(\ell_p\) 与任意更大的 \(\ell_p'\)，从而不可能唯一决定 \(\ell_p\)。证毕。
+\end{proof}
+
+\begin{corollary}[有限素数联合读出的最小预算由 Ramanujan 阴影完全决定]\label{cor:conclusion-prime-register-stage-ramanujan-shadow-recovers-budget}
+在上述记号下，寄存秩 \(r\) 的有限素数联合读出的最小离散寄存规模与最小比特预算
+\[
+\min\card{R_{S,\boldsymbol\ell}}=M_{S,\boldsymbol\ell}^{\,r},
+\qquad
+\mathsf{bits}_{\min}(S,\boldsymbol\ell)=r\log_2 M_{S,\boldsymbol\ell}
+=
+r\sum_{p\in S}\ell_p\log_2 p
+\]
+都由 prime-power Ramanujan 阴影族
+\[
+\bigl\{\mathcal A_{S,\boldsymbol\ell}(p^k)\bigr\}_{p\in \mathbb P,\ k\ge 1}
+\]
+唯一恢复。
+\end{corollary}
+\begin{proof}
+由定理 \ref{thm:conclusion-prime-register-stage-ramanujan-layer-detection}，可逐个恢复全部指数 \(\ell_p\)，从而唯一恢复
+\[
+M_{S,\boldsymbol\ell}=\prod_{p\in S}p^{\ell_p}.
+\]
+再由定理 \ref{thm:conclusion-boundary-finite-prime-selector-product-law}，联合读出的最小寄存规模与最小比特预算正是 \(M_{S,\boldsymbol\ell}\) 的上述函数。故结论成立。证毕。
+\end{proof}
+
+\begin{theorem}[局部化群的 Pontryagin 核由 squarefree Ramanujan 阴影唯一决定]\label{thm:conclusion-squarefree-ramanujan-shadow-recovers-localization-kernel}
+设 \(S\subset \mathbb P\) 为有限素数集，并记
+\[
+N_S:=\prod_{p\in S}p,
+\qquad
+\mathcal A_S(q):=c_q(N_S).
+\]
+则对任意素数 \(p\)，有
+\[
+\mathbf 1_{\{p\in S\}}
+=
+\frac{1+\mathcal A_S(p)}{p}.
+\]
+从而 \(S\) 可由 \(\{\mathcal A_S(p)\}_{p\in\mathbb P}\) 唯一恢复；进而 Pontryagin 核
+\[
+K_S:=\prod_{p\in S}\ZZ_p
+\]
+以及短正合扩张
+\[
+0\longrightarrow K_S\longrightarrow \widehat{\ZZ[S^{-1}]}\longrightarrow \TT\longrightarrow 0
+\]
+也都由 squarefree Ramanujan 阴影唯一决定。
+\end{theorem}
+\begin{proof}
+对素数 \(p\)，Ramanujan 和满足显式公式
+\[
+c_p(n)=
+\begin{cases}
+p-1,& p\mid n,\\
+-1,& p\nmid n.
+\end{cases}
+\]
+取 \(n=N_S\) 即得
+\[
+\mathcal A_S(p)=
+\begin{cases}
+p-1,& p\in S,\\
+-1,& p\notin S.
+\end{cases}
+\]
+因此
+\[
+\mathbf 1_{\{p\in S\}}=\frac{1+\mathcal A_S(p)}{p}.
+\]
+由此逐个素数恢复 \(S\)。
+
+另一方面，定理 \ref{thm:conclusion-finite-prime-solenoid-terminal-object} 已给出短正合列
+\[
+0\longrightarrow \prod_{p\in S}\ZZ_p\longrightarrow \widehat{\ZZ[S^{-1}]}\longrightarrow \TT\longrightarrow 0,
+\]
+而定理 \ref{thm:conclusion-finite-prime-localization-pontryagin-rigidity} 说明 \(S\) 唯一决定对应的局部化群与其 Pontryagin 对偶。故 squarefree Ramanujan 阴影唯一决定 \(K_S\) 及其扩张。证毕。
+\end{proof}
+
+\begin{theorem}[有限导子 Ramanujan 审计的 prime-tail 结构性失明]\label{thm:conclusion-finite-conductor-ramanujan-prime-tail-blindness}
+设 \(\mathcal Q\subset \NN_{\ge 1}\) 为任意有限导子集合，并记其素数支撑
+\[
+P(\mathcal Q):=\bigcup_{q\in\mathcal Q}\{p\in\mathbb P:\ v_p(q)>0\}.
+\]
+设两组 stage 数据 \((S,\boldsymbol\ell)\) 与 \((S',\boldsymbol\ell')\) 满足：对一切 \(p\in P(\mathcal Q)\)，都有
+\[
+\ell_p=\ell_p',
+\]
+其中对 \(p\notin S\) 或 \(p\notin S'\) 仍约定相应指数为 \(0\)。则对每个 \(q\in\mathcal Q\)，有
+\[
+\mathcal A_{S,\boldsymbol\ell}(q)=\mathcal A_{S',\boldsymbol\ell'}(q).
+\]
+特别地，任何有限导子 Ramanujan 审计都无法探测其素数支撑之外的 prime-tail。
+\end{theorem}
+\begin{proof}
+把任意 \(q\in\mathcal Q\) 写成
+\[
+q=\prod_{p}p^{a_p},
+\qquad
+a_p=v_p(q).
+\]
+由于 Ramanujan 和关于导子 \(q\) 乘法分解，故
+\[
+\mathcal A_{S,\boldsymbol\ell}(q)
+=
+c_q(M_{S,\boldsymbol\ell})
+=
+\prod_{a_p>0}c_{p^{a_p}}(M_{S,\boldsymbol\ell})
+=
+\prod_{a_p>0}c_{p^{a_p}}(p^{\ell_p}),
+\]
+其中最后一步使用了每个局部因子只依赖于相应的 \(p\)-进赋值 \(v_p(M_{S,\boldsymbol\ell})=\ell_p\)。同理，
+\[
+\mathcal A_{S',\boldsymbol\ell'}(q)
+=
+\prod_{a_p>0}c_{p^{a_p}}(p^{\ell_p'}).
+\]
+但 \(a_p>0\) 只可能发生在 \(p\in P(\mathcal Q)\)，而在该集合上已假定 \(\ell_p=\ell_p'\)。故两乘积逐因子相同，从而
+\[
+\mathcal A_{S,\boldsymbol\ell}(q)=\mathcal A_{S',\boldsymbol\ell'}(q)
+\qquad (q\in\mathcal Q).
+\]
+证毕。
+\end{proof}
+
+\begin{conjecture}[prime-register Ramanujan 阴影的极小完备性]\label{conj:conclusion-prime-register-ramanujan-shadow-minimal-completeness}
+在一切仅依赖于有限 stage 模
+\[
+M_{S,\boldsymbol\ell}=\prod_{p\in S}p^{\ell_p}
+\]
+并同时满足以下三条的统计族中：
+\begin{enumerate}
+  \item 仅以逐素数的 \(p\)-进层数据为变量；
+  \item 对有限素数联合读出的最小寄存规模与最小比特预算完备；
+  \item 允许逐素数的精确 cutoff 判别，
+\end{enumerate}
+prime-power Ramanujan 阴影族
+\[
+\bigl\{\mathcal A_{S,\boldsymbol\ell}(p^k)\bigr\}_{p\in\mathbb P,\ k\ge 1}
+\]
+应当是极小完备坐标：删去任意一个对某个 stage 必要的层 \(p^k\)，便会失去对某个指数 \(\ell_p\) 的统一可辨识性。
+
+更具体地说，这应是猜想 \ref{conj:conclusion-smith-ramanujan-shadow-initiality} 在 prime-register stage 塔上的对应版本：定理 \ref{thm:conclusion-prime-register-stage-ramanujan-layer-detection} 给出逐层可逆恢复，定理 \ref{thm:conclusion-prime-register-stage-ramanujan-exact-cutoff} 给出精确 cutoff，推论 \ref{cor:conclusion-prime-register-stage-ramanujan-shadow-recovers-budget} 表明联合预算只是这些层的函子像，而定理 \ref{thm:conclusion-finite-conductor-ramanujan-prime-tail-blindness} 又说明任何有限导子审计都必然存在 prime-tail 盲区。若该猜想成立，则 prime-register 预算、局部化对偶核与 finite-stage 译码将被最终压缩到同一条 Ramanujan prime-power 图册之内。
+\end{conjecture}
+
+\paragraph{统一读法}
+这条链把 prime-register stage、局部化对偶与有限导子审计压到了同一组 Ramanujan 坐标上。prime-power 阴影逐层恢复每个 \(p\)-进深度，并强制最短充分前缀恰为 \(\ell_p+1\)；所有联合寄存预算只是这些深度的乘法编译；squarefree 阴影又在最粗层上直接刻出 Pontryagin 核的素支撑；而有限导子审计的 blind tail 则只是 Ramanujan 局部性在有限支撑上的必然后果。与定理 \ref{thm:conclusion-boundary-prime-tail-blindness} 所揭示的连续相位通道失明并列可见，这里的 prime-tail 盲区并非技术障碍，而是 prime-register stage 塔在 Ramanujan 坐标下的结构定律。
+
+\endinput

--- a/theory/2026_golden_ratio_driven_scan_projection_generation_recursive_emergence/sections/body/conclusion/subsec__conclusion-solenoid-poissoncauchy-primelog-finitecomb-canonical-nogo.tex
+++ b/theory/2026_golden_ratio_driven_scan_projection_generation_recursive_emergence/sections/body/conclusion/subsec__conclusion-solenoid-poissoncauchy-primelog-finitecomb-canonical-nogo.tex
@@ -1,0 +1,334 @@
+\subsection{局部化 solenoid 商格、Poisson--Cauchy 超四阶熵塌缩与 prime-log canonical system 的有限秩障碍}\label{subsec:conclusion-solenoid-poissoncauchy-primelog-finitecomb-canonical-nogo}
+沿用定理
+\ref{thm:conclusion-finite-primesupport-exact-quotient}、
+\ref{thm:conclusion-finite-prime-localization-pontryagin-rigidity}、
+\ref{thm:conclusion-poisson-kl-sixth-coefficient-negative-monotone-approach}、
+\ref{thm:conclusion-poisson-bivariate-quartic-null-cone-covariance-balance}、
+\ref{cor:conclusion-poisson-bivariate-quartic-null-cone-fdiv-universal}、
+\ref{thm:conclusion-prime-log-weighted-boundary-log-singularity}、
+\ref{thm:conclusion-prime-log-rh-operator-countable-prime-rank}、
+\ref{cor:conclusion-prime-log-congruence-kernel-not-rh-operator}、
+\ref{cor:conclusion-bivariate-finitewindow-finite-comb-rigidity}
+与猜想
+\ref{conj:conclusion-prime-log-boundary-mass-canonical-system}
+的记号。前述链条已经分别给出：有限 prime-support 在 Pontryagin 对偶侧的 exact quotient calculus、Poisson--Cauchy 一维 KL 通道的 sextic 负校正与二维位置--尺度模型的 quartic 零锥、以及 centered prime-log 势在 RH 路线中的无限秩边界流语义。把这些接口与 finite-dimensional toy-RH 的梳齿刚性并读后，还可继续压缩出如下六条跨节终端后果：固定 ambient solenoid 内部的 Boolean 商格、sixth-order 熵校正项的严格负号与显式余量、超四阶熵塌缩对尺度随机性的必要性、有限秩 congruence-twist 闭类对 prime-log 边界流的结构性失效、有限维临界相位的归一化 finite-comb 刻画，以及由此逼出的 prime-log canonical system 初对象猜想。
+
+\begin{theorem}[局部化 solenoid 的 Boolean 商格]\label{thm:conclusion-solenoid-boolean-quotient-lattice}
+设 \(S\subset \mathbb P\) 为有限素数集，
+\[
+G_S:=\ZZ[S^{-1}],
+\qquad
+\widehat G_S:=\widehat{G_S}.
+\]
+则对任意 \(T\subseteq S\)，存在自然短正合列
+\[
+0\longrightarrow \prod_{p\in S\setminus T}\ZZ_p
+\longrightarrow \widehat G_S
+\xrightarrow{\ \pi_{S,T}\ }
+\widehat G_T
+\longrightarrow 0.
+\]
+因而赋值
+\[
+T\longmapsto \widehat G_T
+\]
+把 Boolean 格 \(\mathcal P(S)\) 反变地嵌入 \(\widehat G_S\) 的闭全不连通核商格；并且核
+\[
+\ker(\pi_{S,T})\cong \prod_{p\in S\setminus T}\ZZ_p
+\]
+唯一记录了被删除的素数集合 \(S\setminus T\)。
+\end{theorem}
+\begin{proof}
+定理 \ref{thm:conclusion-finite-primesupport-exact-quotient} 已经对任意有限素数集包含
+\[
+T\subseteq S
+\]
+给出自然短正合列
+\[
+0\to \prod_{p\in S\setminus T}\ZZ_p\to \widehat G_S\to \widehat G_T\to 0.
+\]
+因此每个 \(T\subseteq S\) 都定义了 \(\widehat G_S\) 的一个带全不连通核的标准商。另一方面，定理 \ref{thm:conclusion-finite-prime-localization-pontryagin-rigidity} 表明：对任意有限 \(U\subset \mathbb P\)，\(\widehat G_U\) 的全不连通核之 \(p\)-主因子非平凡当且仅当 \(p\in U\)。于是
+\[
+\ker(\pi_{S,T})\cong \prod_{p\in S\setminus T}\ZZ_p
+\]
+的 prime support 恰为 \(S\setminus T\)，从而不同的 \(T\) 给出不同的商。故 \(\mathcal P(S)\) 被反变实现为 \(\widehat G_S\) 内部的一条 Boolean 商格。证毕。
+\end{proof}
+
+\begin{theorem}[Poisson--Cauchy 相对熵的 sixth-order 校正项严格为负]\label{thm:conclusion-poisson-cauchy-kl-sixth-correction-negative-lowerbound}
+设 \(\widetilde\nu\in\mathcal P(\RR)\) 具有有限六阶矩，均值为 \(\bar\gamma\)，中心矩记为 \(\mu_k\)，并置
+\[
+\sigma^2:=\mu_2>0,
+\qquad
+\widetilde h_t:=P_t*\widetilde\nu,
+\qquad
+\widetilde g_t(x):=P_t(x-\bar\gamma).
+\]
+则当 \(t\to\infty\) 时，
+\[
+D_{\mathrm{KL}}(\widetilde h_t\mid \widetilde g_t)
+=
+\frac{\sigma^4}{8t^4}
+-\frac{C_6(\widetilde\nu)}{t^6}
++o(t^{-6}),
+\]
+其中
+\[
+C_6(\widetilde\nu)
+:=
+-\left(
+\frac{\sigma^6}{64}
+-\frac{\sigma^2\mu_4}{8}
++\frac{3\mu_3^2}{32}
+\right)
+>0.
+\]
+更强地，有显式下界
+\[
+C_6(\widetilde\nu)\ge \frac{7\sigma^6+2\mu_3^2}{64}.
+\]
+\end{theorem}
+\begin{proof}
+由定理 \ref{thm:conclusion-poisson-kl-sixth-coefficient-negative-monotone-approach} 的 sextic 展开，
+\[
+D_{\mathrm{KL}}(\widetilde h_t\mid \widetilde g_t)
+=
+\frac{\sigma^4}{8t^4}
++
+\frac{1}{t^6}
+\left(
+\frac{\sigma^6}{64}
+-\frac{\sigma^2\mu_4}{8}
++\frac{3\mu_3^2}{32}
+\right)
++o(t^{-6}).
+\]
+因此只需估计括号中的系数。由 Pearson 矩不等式
+\[
+\mu_4\ge \sigma^4+\frac{\mu_3^2}{\sigma^2},
+\]
+得到
+\[
+64\left(
+\frac{\sigma^6}{64}
+-\frac{\sigma^2\mu_4}{8}
++\frac{3\mu_3^2}{32}
+\right)
+\le
+\sigma^6-8\left(\sigma^6+\mu_3^2\right)+6\mu_3^2
+=
+-7\sigma^6-2\mu_3^2<0.
+\]
+故六阶系数严格为负。再把上式移项，便得
+\[
+C_6(\widetilde\nu)
+=
+-\left(
+\frac{\sigma^6}{64}
+-\frac{\sigma^2\mu_4}{8}
++\frac{3\mu_3^2}{32}
+\right)
+\ge
+\frac{7\sigma^6+2\mu_3^2}{64}.
+\]
+证毕。
+\end{proof}
+
+\begin{theorem}[超四阶熵塌缩要求非平凡尺度随机性参与补偿]\label{thm:conclusion-poisson-cauchy-superquartic-collapse-needs-scale-randomness}
+在二维 Poisson--Cauchy 粗粒化模型
+\[
+h_t(x):=\EE[P_{t+\Delta}(x-\Gamma)],
+\qquad
+g_t(x):=P_{t+\bar\delta}(x-\bar\gamma)
+\]
+中，记
+\[
+\sigma_\gamma^2:=\Var(\Gamma),
+\qquad
+\sigma_\delta^2:=\Var(\Delta),
+\qquad
+\sigma_{\gamma\delta}:=\Cov(\Gamma,\Delta).
+\]
+若某个相对熵或任意满足 \(f''(1)\neq 0\) 的光滑 Csisz\'ar \(f\)-散度满足
+\[
+D_f(h_t\mid g_t)=o((t+\bar\delta)^{-4}),
+\]
+并且模型非退化，则必有
+\[
+\Var(\Delta)=\Var(\Gamma)>0,
+\qquad
+\Cov(\Gamma,\Delta)=0.
+\]
+特别地，若 \(\Delta\) 几乎处处为常数；尤其在归一化纯平移口径 \(\Delta\equiv 0\) 下，则除退化情形 \(\Var(\Gamma)=0\) 外，不可能发生从 \(t^{-4}\) 到 \(t^{-6}\) 的提升。换言之，任何真正的超四阶熵塌缩都不是单纯位置随机性的产物，而必须由内禀尺度随机性参与补偿。
+\end{theorem}
+\begin{proof}
+由推论 \ref{cor:conclusion-poisson-bivariate-quartic-null-cone-fdiv-universal}，对任意满足 \(f''(1)\neq 0\) 的光滑 \(f\)-散度，都有
+\[
+(t+\bar\delta)^4D_f(h_t\mid g_t)\longrightarrow \frac{f''(1)}{8}\,(A^2+4B^2),
+\]
+其中
+\[
+A:=\Var(\Gamma)-\Var(\Delta),
+\qquad
+B:=\Cov(\Gamma,\Delta).
+\]
+因此若 \(D_f(h_t\mid g_t)=o((t+\bar\delta)^{-4})\)，则必有
+\[
+A=0,
+\qquad
+B=0,
+\]
+也就是
+\[
+\Var(\Gamma)=\Var(\Delta),
+\qquad
+\Cov(\Gamma,\Delta)=0.
+\]
+若模型非退化，则 \(\Var(\Gamma)>0\) 或 \(\Var(\Delta)>0\) 至少一者成立；而由 \(\Var(\Gamma)=\Var(\Delta)\) 可知二者必须同时为正，因此
+\[
+\Var(\Delta)=\Var(\Gamma)>0.
+\]
+
+若进一步 \(\Delta\) 几乎处处为常数，则 \(\Var(\Delta)=0\) 且 \(\Cov(\Gamma,\Delta)=0\) 自动成立。此时欲使 quartic 主项消失，只能再有
+\[
+\Var(\Gamma)=0,
+\]
+故纯平移情形除完全退化外不可能提升到 sextic 制度。证毕。
+\end{proof}
+
+\begin{theorem}[有限秩 congruence-twist 封闭类不能忠实承载 prime-log 边界流]\label{thm:conclusion-prime-log-finite-rank-congruence-twist-class-nogo}
+设 \(\mathcal C_{\mathrm{fin}}\) 为如下模型类：从有限维矩阵核或有限状态同步核出发，仅允许施加有限次直和、张量积、有限多个 root-of-unity/模计数 Dirichlet 扭曲，以及有限秩 Lie 型可见因子。则 \(\mathcal C_{\mathrm{fin}}\) 中不存在任何对象能够充当文内 prime-log 路线的 RH 目标算子，以忠实承载定理 \ref{thm:conclusion-prime-log-weighted-boundary-log-singularity} 的边界流 \(\Psi_\alpha\)。更具体地，任何此类模型都必然遗漏 centered prime-log 势
+\[
+\psi_\alpha(j)=y_jw_j-c,
+\]
+从而无法恢复真正的边界驱动变量。
+\end{theorem}
+\begin{proof}
+先看解析几何侧。定理 \ref{thm:conclusion-finite-dimensional-normalized-critical-phase-finite-comb} 表明：任意有限维 \(\zeta\)-型矩阵核在归一化临界相位坐标中都只能产生有限个 \(\ZZ\)-陪集之并。有限状态同步核经其有限状态转移矩阵实现后仍属于同一有限维框架；而有限次直和、张量积与有限多个 root-of-unity 扭曲，只会把临界相位集合做有限并、有限和或有限平移，因此整个 \(\mathcal C_{\mathrm{fin}}\) 仍被困在 finite-comb 机制中。
+
+再看算术侧。推论 \ref{cor:conclusion-prime-log-congruence-kernel-not-rh-operator} 已经表明：仅由模计数/Dirichlet 扭曲驱动的候选核不能充当承载 \(\Psi_\alpha\) 的 RH 目标算子，缺失变量正是 centered prime-log 势 \(\psi_\alpha\) 本身，而不是更多有限同余通道。
+
+最后看结构层。定理 \ref{thm:conclusion-prime-log-rh-operator-countable-prime-rank} 说明：任何若要忠实记录对应 prime-log 乘法数据并恢复边界流 \(\Psi_\alpha\) 的候选算子，都必须保留可数无限多个 prime directions；其最小局部化轴复杂度满足
+\[
+\ell_{\mathrm{loc}}=\aleph_0,
+\]
+从而不可能闭合在任何有限秩加法账本、其 Pontryagin 对偶，或任何有限维 Lie 可见宿主上。故 \(\mathcal C_{\mathrm{fin}}\) 无法同时越过 finite-comb 刚性、同余扭曲失效与可数 prime-rank 障碍，自然不可能忠实承载 \(\Psi_\alpha\)。证毕。
+\end{proof}
+
+\begin{theorem}[归一化临界相位的 finite-comb 刚性]\label{thm:conclusion-finite-dimensional-normalized-critical-phase-finite-comb}
+设 \(M\) 为有限维矩阵，\(\lambda:=\rho(M)>1\)，并定义其 \(s\)-变量 \(\zeta\)-模型
+\[
+\zeta_M(s):=\det(I-\lambda^{-s}M)^{-1}.
+\]
+记临界模特征值集合
+\[
+\Sigma_c(M):=
+\left\{
+\mu\in \Spec(M)\setminus\{0\}:\ |\mu|=\sqrt{\lambda}
+\right\},
+\]
+相位集合
+\[
+\Phi_c(M):=
+\left\{
+\vartheta\in \RR/\ZZ:\ \sqrt{\lambda}\,e^{2\pi i\vartheta}\in \Sigma_c(M)
+\right\},
+\]
+以及归一化临界纵坐标集
+\[
+\mathcal U_c(M):=
+\bigcup_{\vartheta\in\Phi_c(M)}(\vartheta+\ZZ)\subset \RR.
+\]
+则 \(\zeta_M\) 在临界线 \(\Re(s)=1/2\) 上的全部极点恰为
+\[
+\left\{
+\frac12+\frac{2\pi i}{\log\lambda}\,u:\ u\in\mathcal U_c(M)
+\right\}.
+\]
+因而，有限维模型的归一化临界纵坐标永远属于有限个整数晶格平移的并。特别地，若某候选临界几何在归一化相位坐标中不是有限个 \(\ZZ\)-陪集之并，则它不可能来自任何有限维矩阵核。
+\end{theorem}
+\begin{proof}
+任取
+\[
+\mu=\sqrt{\lambda}\,e^{2\pi i\vartheta}\in \Sigma_c(M).
+\]
+\(\zeta_M\) 的极点对应于
+\[
+1-\lambda^{-s}\mu=0.
+\]
+若写
+\[
+s=\sigma+it,
+\]
+则
+\[
+\lambda^{-s}\mu
+=
+e^{-\sigma\log\lambda}\,e^{-it\log\lambda}\,\sqrt{\lambda}\,e^{2\pi i\vartheta}.
+\]
+上式等于 \(1\) 当且仅当模与辐角同时匹配。模长条件给出
+\[
+e^{-\sigma\log\lambda}\sqrt{\lambda}=1
+\qquad\Longleftrightarrow\qquad
+\sigma=\frac12.
+\]
+辐角条件给出
+\[
+-t\log\lambda+2\pi\vartheta\in 2\pi\ZZ,
+\]
+亦即
+\[
+t=\frac{2\pi}{\log\lambda}(\vartheta+n),
+\qquad n\in\ZZ.
+\]
+对全部 \(\vartheta\in \Phi_c(M)\) 取并，便得到
+\[
+\left\{
+\frac12+\frac{2\pi i}{\log\lambda}\,u:\ u\in\mathcal U_c(M)
+\right\}
+\]
+的精确描述。由于 \(\Phi_c(M)\) 仅由有限维矩阵的有限个特征值相位组成，故 \(\mathcal U_c(M)\) 必为有限个 \(\ZZ\)-陪集之并。证毕。
+\end{proof}
+
+\begin{conjecture}[prime-log canonical system 的初对象性]\label{conj:conclusion-prime-log-canonical-system-initiality}
+存在定义在可数 prime-register 差额空间上的 de Branges/canonical system
+\[
+\mathcal H_\alpha,
+\]
+满足下列三条同时成立：
+\begin{enumerate}
+  \item 其可见商恰为唯一圆相位因子
+  \[
+  \TT\cong U(1);
+  \]
+  \item 其隐藏核由 prime-register 差额方向生成，并允许定理 \ref{thm:conclusion-solenoid-boolean-quotient-lattice} 的 prime-deletion 商；
+  \item 其边界 Weyl 数据的驱动势正是
+  \[
+  \psi_\alpha(j)=y_jw_j-c,
+  \]
+  并在 Abel--Mellin 提升后产生定理 \ref{thm:conclusion-prime-log-weighted-boundary-log-singularity} 的边界流 \(\Psi_\alpha\)。
+\end{enumerate}
+并且，在“忠实承载本文 prime-log 边界流”的自伴模型范畴中，\(\mathcal H_\alpha\) 为初对象：任何其他忠实模型都必须经由
+\begin{enumerate}
+  \item 可见圆商上的保持相位商映射；
+  \item hidden prime-register 上的闭嵌入或 prime-deletion 商；
+  \item 以及至多紧扰动的谱修正，
+\end{enumerate}
+从 \(\mathcal H_\alpha\) 因子化而来。
+\end{conjecture}
+
+\paragraph{统一读法}
+这条跨节闭链可压缩为
+\[
+\text{finite-support solenoidal quotient lattice}
+\Longrightarrow
+\text{Poisson--Cauchy quartic bottleneck and sextic correction}
+\Longrightarrow
+\text{finite-rank congruence-twist no-go}
+\Longrightarrow
+\text{finite-comb rigidity}
+\Longrightarrow
+\text{prime-log canonical system initiality}.
+\]
+其结构含义是：局部化 solenoid 的有限素数删除已经在 compact--profinite 侧形成精确 Boolean 商格；Poisson--Cauchy 粗粒化则表明超四阶熵塌缩只有在尺度随机性参与补偿时才可能发生；而一旦把这种高阶熵刚性与 prime-log 边界流、finite-comb toy-RH 几何及可数 prime-register 障碍并读，有限维核、有限次 congruence twist 与有限秩 Lie-visible 因子便同时被排除在 faithful RH 宿主之外。于是，centered prime-log 势在可数差额空间上的 canonical-system 谱实现，不再只是启发式猜想，而成为当前文稿内部最自然的唯一去向。
+
+\endinput

--- a/theory/2026_golden_ratio_driven_scan_projection_generation_recursive_emergence/sections/body/conclusion/subsec__conclusion-window6-boundary-detector-sideinfo-stack-rigidity.tex
+++ b/theory/2026_golden_ratio_driven_scan_projection_generation_recursive_emergence/sections/body/conclusion/subsec__conclusion-window6-boundary-detector-sideinfo-stack-rigidity.tex
@@ -1,0 +1,193 @@
+\subsection{window-\texorpdfstring{$6$}{6} boundary parity 的 faithful 探测下界、超选成本与叠型宿主}\label{subsec:conclusion-window6-boundary-detector-sideinfo-stack-rigidity}
+在定理 \ref{thm:conclusion-window6-boundary-conductor-two-zeta-flatness} 与推论 \ref{cor:conclusion-window6-boundary-conductor-two-plancherel-uniformity} 已把导子 \(2\) 的 boundary 中央扇区在表示 \(\zeta\)、一维相位数与 Plancherel 质量上严格等分之后，还可继续抽出一条更偏对象论的刚性链：sector-wise 表示平坦并不会削弱 boundary parity 的 faithful 探测成本；相反，一切仅经连通有理证书起作用的 detector 都被迫把真正的区分能力压到离散连通分量上，而任何额外的超选先验又只能线性削减精确重建的剩余维数成本。与此同时，由 \(F_8\) 修复位与有理连续证书生成的最小可观测代数对 canonical boundary parity 仍然完全失明；若要在更高窗口上重新获得与 \(m=6\) 相容的二层 parity，则其真正的宿主应不再是通常的连通局部系统，而应是一类带外部门控的 \(2\)-primary 下降对象。
+
+\begin{theorem}[faithful boundary 探测的离散连通分量下界]\label{thm:conclusion-window6-boundary-faithful-detector-component-lower-bound}
+设
+\[
+P_6:=Z_6^{\mathrm{bd}}\cong (\ZZ/2\ZZ)^3
+\]
+为 window-\(6\) 的 canonical boundary parity 群，并设 \((H,\Phi)\) 为一个 boundary detector，其中 \(H\) 为紧群，\(\Phi:P_6\to H\) 为群同态。
+
+若 \(H^\circ\) 的可用连续观测只允许通过 \(\QQ\)-系数 de Rham/Sullivan/有理特征类证书起作用，则若 \((H,\Phi)\) 在 \(P_6\) 上 faithful，必有
+\[
+(\ZZ/2\ZZ)^3\hookrightarrow \pi_0(H),
+\qquad\text{从而}\qquad
+|\pi_0(H)|\ge 8.
+\]
+
+若进一步允许 connected 部分完全吸收主文中唯一几何可实现的同步对角子群
+\[
+P_6^{\mathrm{geo}}=\langle(1,1,1)\rangle\cong \ZZ/2\ZZ,
+\]
+但除此之外不允许 connected 部分探测更多 parity，则 faithful 探测仍强制
+\[
+P_6/P_6^{\mathrm{geo}}\cong (\ZZ/2\ZZ)^2 \hookrightarrow \pi_0(H),
+\qquad\text{从而}\qquad
+|\pi_0(H)|\ge 4.
+\]
+\end{theorem}
+\begin{proof}
+由定理 \ref{thm:conclusion-window6-boundary-parity-directsummand-rational-blindness}，\(P_6\) 对所有 \(\QQ\)-系数连通有理证书完全失显；由定理 \ref{thm:conclusion-window6-boundary-parity-zero-one-three-law} 与定理 \ref{thm:conclusion-window6-boundary-parity-three-layer-blind-filtration}，强局域 geometric uplift 唯一可实现的部分恰为
+\[
+P_6^{\mathrm{geo}}=\langle(1,1,1)\rangle.
+\]
+
+先证第一种情形。若 \(g_1,g_2\in P_6\) 满足 \(\Phi(g_1),\Phi(g_2)\) 落在 \(H\) 的同一连通分量中，则一切只经 \(H^\circ\) 的 \(\QQ\)-系数连续证书起作用的观测都无法把它们区分。faithful 性遂迫使不同的 parity 元必须落在不同的连通分量上，即 \(\Phi\) 在 \(\pi_0(H)\) 上诱导单射
+\[
+P_6\hookrightarrow \pi_0(H).
+\]
+故 \(\pi_0(H)\) 至少包含一个秩 \(3\) 的初等 \(2\)-群子群，特别地 \(|\pi_0(H)|\ge 8\)。
+
+第二种情形中，connected 部分被允许完全吸收 \(P_6^{\mathrm{geo}}\)，故 remaining detector 的 faithful 性至多可能在商群
+第二种情形中，connected 部分被允许完全吸收 \(P_6^{\mathrm{geo}}\)，故剩余探测器的 faithful 性至多可能在商群
+\[
+P_6/P_6^{\mathrm{geo}}\cong (\ZZ/2\ZZ)^2
+\]
+上失败。若它仍 faithful，则该商必须注入 \(\pi_0(H)\)。于是 \(\pi_0(H)\) 至少含一个秩 \(2\) 的初等 \(2\)-群子群，故 \(|\pi_0(H)|\ge 4\)。证毕。
+\end{proof}
+
+\begin{corollary}[连通 faithful boundary detector 的不可能性]\label{cor:conclusion-window6-boundary-faithful-connected-detector-impossible}
+不存在任何连通紧群 \(H\)，使得一个只经 \(\QQ\)-系数连通有理证书起作用的 boundary detector \((H,\Phi)\) 能够在 \(P_6\) 上 faithful。更强地，即便允许 \(H^\circ\) 完全吸收几何对角子群 \(P_6^{\mathrm{geo}}\)，faithful 探测仍至少需要四个连通分量。
+\end{corollary}
+\begin{proof}
+若 \(H\) 连通，则 \(\pi_0(H)=0\)，与定理 \ref{thm:conclusion-window6-boundary-faithful-detector-component-lower-bound} 的第一部分矛盾。若允许 connected 部分吸收 \(P_6^{\mathrm{geo}}\)，则仍需
+\[
+(\ZZ/2\ZZ)^2\hookrightarrow \pi_0(H),
+\]
+故至少要有 \(|\pi_0(H)|\ge 4\) 个连通分量。证毕。
+\end{proof}
+
+\begin{theorem}[超选信息不能显著削减精确重建成本]\label{thm:conclusion-window6-boundary-superselection-sideinfo-cost-lower-bound}
+记
+\[
+B_6:=C_6(Q_1;\FF_2)\cong \FF_2^{64},
+\qquad
+V_6:=\bigl(G_6^{\mathrm{bin}}\bigr)^{\mathrm{ab}}\cong \FF_2^{21}.
+\]
+设 \(S\) 为一个额外 classical side-information 寄存器，并满足
+\[
+\dim_{\FF_2}S=r.
+\]
+若存在 \(\FF_2\)-线性的精确因子化
+\[
+B_6 \xrightarrow{\ \iota\ } V_6\oplus S\oplus R
+\xrightarrow{\ \pi\ } B_6,
+\qquad
+\pi\circ \iota=\mathrm{id}_{B_6},
+\]
+则必有
+\[
+\dim_{\FF_2}R\ge 43-r.
+\]
+
+特别地：
+\begin{enumerate}
+  \item 若 \(S\) 记录完整的 boundary 八重超选扇区标签，则 \(r=3\)，从而
+  \[
+  \dim_{\FF_2}R\ge 40;
+  \]
+  \item 若 \(S\) 仅记录几何可实现的同步对角 parity 标签，则 \(r=1\)，从而
+  \[
+  \dim_{\FF_2}R\ge 42.
+  \]
+\end{enumerate}
+\end{theorem}
+\begin{proof}
+由 \(\pi\circ\iota=\mathrm{id}_{B_6}\) 可知 \(\iota\) 必为单射，故
+\[
+\dim_{\FF_2}B_6
+\le
+\dim_{\FF_2}(V_6\oplus S\oplus R)
+\]
+即
+\[
+64\le 21+r+\dim_{\FF_2}R.
+\]
+整理即得
+\[
+\dim_{\FF_2}R\ge 43-r.
+\]
+
+另一方面，由定理 \ref{thm:conclusion-window6-boundary-conductor-two-zeta-flatness} 与推论 \ref{cor:conclusion-window6-boundary-conductor-two-plancherel-uniformity}，完整 boundary 超选结构正对应
+\[
+P_6=Z_6^{\mathrm{bd}}\cong (\ZZ/2\ZZ)^3,
+\]
+故完整扇区标签只贡献 \(r=3\) 比特；而由定理 \ref{thm:conclusion-window6-boundary-parity-zero-one-three-law}，几何可实现部分仅为
+\[
+P_6^{\mathrm{geo}}\cong \ZZ/2\ZZ,
+\]
+故几何同步对角标签只贡献 \(r=1\) 比特。代入上式即得两条特化结论。证毕。
+\end{proof}
+
+\begin{proposition}[由 \(F_8\) 修复位与有理连续证书生成的可观测代数对 boundary parity 完全失明]\label{prop:conclusion-window6-boundary-f8-rational-generated-algebra-blind}
+记
+\[
+B:=\bigcup_{w\in X_6^{\mathrm{bdry}}}\bigl(\Fold_6^{\mathrm{bin}}\bigr)^{-1}(w)
+\]
+为三条 boundary 二点纤维之并。令 \(\mathcal A_{\mathrm{rat},F_8}\) 为满足下列条件的最小复代数：
+\begin{enumerate}
+  \item 包含 \(b_6^{\mathrm{bin}}\!\restriction_B\)；
+  \item 包含一切来自 \(K_6\) 的 \(\QQ\)-系数 de Rham/Sullivan 型连续证书限制到 \(B\) 上的函数；
+  \item 对加法、乘法与复共轭封闭。
+\end{enumerate}
+则 \(\mathcal A_{\mathrm{rat},F_8}\) 的每个元素都在 \(Z_6^{\mathrm{bd}}\)-轨道上常值。等价地，\(\mathcal A_{\mathrm{rat},F_8}\) 必经由商映射
+\[
+B\longrightarrow B/Z_6^{\mathrm{bd}}
+\]
+因子化，因此不可能 faithful 地探测任何 canonical boundary parity。
+\end{proposition}
+\begin{proof}
+由定理 \ref{thm:conclusion-window6-boundary-parity-not-measurable-from-f8}，
+\[
+b_6^{\mathrm{bin}}\!\restriction_B\equiv 0,
+\]
+故 \(F_8\) 修复位在每条 boundary 二点纤维上恒定，尤其在 \(Z_6^{\mathrm{bd}}\)-轨道上不变。另一方面，由定理 \ref{thm:conclusion-window6-boundary-parity-directsummand-rational-blindness}，所有 \(\QQ\)-系数有理连续证书在 boundary parity 上的拉回恒为零，因此它们限制到 \(B\) 上后同样是 \(Z_6^{\mathrm{bd}}\)-不变函数。
+
+于是，\(\mathcal A_{\mathrm{rat},F_8}\) 的全部生成元都在 \(Z_6^{\mathrm{bd}}\)-轨道上常值；而代数运算与复共轭保持这一不变性，故 \(\mathcal A_{\mathrm{rat},F_8}\) 的任意元素都在 \(Z_6^{\mathrm{bd}}\)-轨道上常值。于是 \(\mathcal A_{\mathrm{rat},F_8}\) 必经由商 \(B/Z_6^{\mathrm{bd}}\) 因子化，不能区分任何非平凡的 boundary sheet-flip。证毕。
+\end{proof}
+
+\begin{corollary}[faithful boundary-aware 解码器必须接入 genuinely non-\texorpdfstring{$F_8$}{F8} 的 \texorpdfstring{$2$}{2}-primary 通道]\label{cor:conclusion-window6-boundary-f8-rational-observable-decoder-fails}
+任何其观测层仅由 \(F_8\) 修复位与 \(\QQ\)-系数有理连续证书生成的 boundary-aware 解码器，都不可能 faithful 地恢复 canonical boundary parity。若要实现 faithful boundary 读出，则必须额外接入 genuinely non-\(F_8\) 的 \(2\)-primary 通道。
+\end{corollary}
+\begin{proof}
+由命题 \ref{prop:conclusion-window6-boundary-f8-rational-generated-algebra-blind}，该观测层所生成的全部可观测函数都在 \(Z_6^{\mathrm{bd}}\)-轨道上常值，故不可能 faithful 区分 canonical boundary parity。再由定理 \ref{thm:conclusion-window6-boundary-f8-f9-channel-orthogonality}，canonical boundary parity 与 \(F_8\) 修复位严格分属不同隐藏通道，因此 faithful 恢复必须引入 genuinely non-\(F_8\) 的 \(2\)-primary 通道。证毕。
+\end{proof}
+
+\begin{conjecture}[cross-scale parity re-locking 的 \texorpdfstring{$2$}{2}-primary 叠性原则]\label{conj:conclusion-window6-boundary-crossscale-parity-stack-principle}
+设 \(\Delta_m^{\mathrm{bdry}}\) 为第 \(m\) 层的 boundary uplift 差集。已知
+\[
+\Delta_6^{\mathrm{bdry}}=\{0,34\},
+\qquad
+\Delta_7^{\mathrm{bdry}}=\{0,55,89\},
+\qquad
+\Delta_8^{\mathrm{bdry}}=\{0,89,144\},
+\]
+因而 \(m=6\) 的二层 parity 并不会 choice-free 地跨尺度延拓。现设存在一族与 restriction 塔相容的协议门
+\[
+\Gamma_m:\Delta_m^{\mathrm{bdry}}\longrightarrow \widehat{\Delta}_m^{\mathrm{bdry}},
+\qquad m\ge 6,
+\]
+使门控后的 \(\widehat{\Delta}_m^{\mathrm{bdry}}\) 在每层都重新获得自由二层对合结构，并与 \(m=6\) 的 canonical boundary parity 相容。则由 \((\Gamma_m)_{m\ge 6}\) 所诱导的跨尺度 parity 数据应当满足：
+\begin{enumerate}
+  \item 它不能由任何连通有理局部系统表示；
+  \item 它必须提升为一个带外部寄存器的 \(2\)-primary 叠对象；
+  \item 该叠的 band 至少应具有一个向
+  \[
+  P_6/P_6^{\mathrm{geo}}\cong (\ZZ/2\ZZ)^2
+  \]
+  的满射；
+  \item 其 connected rational shadow 仍然平凡。
+\end{enumerate}
+换言之，跨尺度 parity 的真正对象论宿主不应是通常意义下的局部系统或向量丛，而应是带离散分量与外部门控下降数据的 \(2\)-primary 叠。
+\end{conjecture}
+\begin{proof}
+定理 \ref{thm:conclusion-window6-choicefree-parity-anchor-isolated} 已表明：choice-free parity 锚点只在 \(m=6\) 存在；定理 \ref{thm:conclusion-window6-no-gateless-crossscale-parity-tower} 更进一步排除了无协议门、无附加寄存器的跨尺度 parity 塔。另一方面，定理 \ref{thm:conclusion-window6-boundary-parity-three-layer-blind-filtration} 与定理 \ref{thm:conclusion-window6-boundary-parity-zero-one-three-law} 说明：有理连续包络对全部 boundary parity 完全失显，而即便允许强局域几何 uplift，也至多保留
+\[
+P_6^{\mathrm{geo}}=\langle(1,1,1)\rangle
+\]
+这一对角子群，剩余 quotient 仍为
+\[
+P_6/P_6^{\mathrm{geo}}\cong (\ZZ/2\ZZ)^2.
+\]
+故若某种 protocol-gated re-locking 确实存在，则它不可能仍落在连通有理局部系统的对象类中；其最自然的宿主只能是带外部寄存器的 \(2\)-primary 下降对象，而 residual 两比特则应作为其 band 的最低非平凡商出现。证毕。
+\end{proof}

--- a/theory/2026_golden_ratio_driven_scan_projection_generation_recursive_emergence/sections/body/conclusion/subsec__conclusion-window6-boundary-rigidity-reentry-anova-externality.tex
+++ b/theory/2026_golden_ratio_driven_scan_projection_generation_recursive_emergence/sections/body/conclusion/subsec__conclusion-window6-boundary-rigidity-reentry-anova-externality.tex
@@ -1,0 +1,391 @@
+\subsection{window-\texorpdfstring{$6$}{6} 的 boundary 横截刚性、再入噪声、三域正交分层与外置信息壁垒}\label{subsec:conclusion-window6-boundary-rigidity-reentry-anova-externality}
+在 window-\(6\) 的 radial 壳层代数、同标签 Hamming 枚举、最小壳层的 Walsh--Spin 对偶、三域 Frobenius 张量乘积密度，以及 canonical boundary parity 的代数/群双层遗忘都已固定之后，还可把这些分散链条进一步压成一组终端结论：boundary 指示函数在 radial 方向上的可吸收能量与横截残差出现精确的 \(11{:}19\) 分裂；同标签关系同时表现出无边、混奇与长程三重几何；window-\(6\) 的稳定概率在超公平噪声处达到唯一严格极小；三域类函数空间在乘积 Chebotarev 密度下给出一个完全显式的 Hoeffding--ANOVA 正交分层；而 boundary 在抽象半单代数层与抽象中心层分别留下 \(56\) 与 \(97155\) 级的遗忘轨道，从而把 faithful boundary parity 的恢复压成一条严格的外置信息壁垒。
+
+\begin{theorem}[boundary 指示函数的 \texorpdfstring{$(11{:}19)$}{(11:19)} 正交分裂]\label{thm:conclusion-window6-boundary-eleven-nineteen-orthogonal-splitting}
+设
+\[
+b:=\mathbf 1_{X_6^{\mathrm{bdry}}}\in C(X_6),
+\qquad
+\mathcal A_{\mathrm{rad}}:=\{P(\mathrm{wt}):\deg P\le 3\}\subset C(X_6),
+\]
+并以归一化计数内积
+\[
+\langle f,g\rangle=\frac1{21}\sum_{w\in X_6}f(w)\overline{g(w)}
+\]
+赋范。记 \(\Pi_{\mathrm{rad}}\) 为到 \(\mathcal A_{\mathrm{rad}}\) 的正交投影。则
+\[
+\Pi_{\mathrm{rad}}b
+=
+\frac{1}{60}\,\mathrm{wt}(\mathrm{wt}-1)(2\mathrm{wt}-1),
+\qquad
+\|b-\Pi_{\mathrm{rad}}b\|_2^2=\frac{19}{210}.
+\]
+并且
+\[
+\|b\|_2^2=\frac17=\frac{30}{210},
+\qquad
+\|\Pi_{\mathrm{rad}}b\|_2^2=\frac{11}{210}.
+\]
+因而
+\[
+\|b\|_2^2=\frac{11}{210}+\frac{19}{210},
+\]
+以及
+\[
+\cos^2\angle\!\bigl(b,\mathcal A_{\mathrm{rad}}\bigr)=\frac{11}{30},
+\qquad
+\sin^2\angle\!\bigl(b,\mathcal A_{\mathrm{rad}}\bigr)=\frac{19}{30}.
+\]
+换言之，boundary 方向中恰有 \(11/30\) 的能量可被 Weyl--radial 壳层代数吸收，而其余 \(19/30\) 构成严格不可压缩的横截残差。
+\end{theorem}
+\begin{proof}
+由定理 \ref{thm:conclusion-window6-boundary-radial-defect}，
+\[
+\Pi_{\mathrm{rad}}b
+=
+\frac{1}{60}\,\mathrm{wt}(\mathrm{wt}-1)(2\mathrm{wt}-1),
+\qquad
+\|b-\Pi_{\mathrm{rad}}b\|_2^2=\frac{19}{210}.
+\]
+另一方面，
+\[
+\|b\|_2^2
+=
+\frac{|X_6^{\mathrm{bdry}}|}{|X_6|}
+=
+\frac{3}{21}
+=
+\frac17.
+\]
+由于 \(\Pi_{\mathrm{rad}}\) 为正交投影，
+\[
+\|b\|_2^2
+=
+\|\Pi_{\mathrm{rad}}b\|_2^2+\|b-\Pi_{\mathrm{rad}}b\|_2^2,
+\]
+故
+\[
+\|\Pi_{\mathrm{rad}}b\|_2^2
+=
+\frac17-\frac{19}{210}
+=
+\frac{11}{210}.
+\]
+再由
+\[
+\cos^2\angle\!\bigl(b,\mathcal A_{\mathrm{rad}}\bigr)
+=
+\frac{\|\Pi_{\mathrm{rad}}b\|_2^2}{\|b\|_2^2}
+\]
+立即得到
+\[
+\cos^2\angle\!\bigl(b,\mathcal A_{\mathrm{rad}}\bigr)=\frac{11}{30},
+\qquad
+\sin^2\angle\!\bigl(b,\mathcal A_{\mathrm{rad}}\bigr)=\frac{19}{30}.
+\]
+证毕。
+\end{proof}
+
+\begin{theorem}[window-\texorpdfstring{$6$}{6} boundary 横截的六原子极小交换放大]\label{thm:conclusion-window6-boundary-six-atom-minimal-commutative-enlargement}
+沿用定理 \ref{thm:conclusion-window6-boundary-eleven-nineteen-orthogonal-splitting} 的记号。则交换代数
+\[
+\CC[\mathrm{wt},b]
+\]
+恰有六个原子，对应于
+\[
+\{\mathrm{wt}=0\},\ \{\mathrm{wt}=1\},\
+X_6^{\mathrm{cyc}}\cap\{\mathrm{wt}=2\},\ X_6^{\mathrm{bdry}}\cap\{\mathrm{wt}=2\},
+\]
+\[
+X_6^{\mathrm{cyc}}\cap\{\mathrm{wt}=3\},\ X_6^{\mathrm{bdry}}\cap\{\mathrm{wt}=3\}.
+\]
+因此
+\[
+\dim_{\CC}\CC[\mathrm{wt},b]=6.
+\]
+更强地，若 \(B\subset C(X_6)\) 是任一交换子代数，同时满足
+\begin{enumerate}
+\normalfont
+  \item \(\mathcal A_{\mathrm{rad}}\subset B\)；
+  \item \(B\) 能区分 boundary/cyclic 在 \(\mathrm{wt}=2,3\) 两层上的分裂，
+\end{enumerate}
+则必有
+\[
+\dim_{\CC}B\ge 6.
+\]
+因此，\(\CC[\mathrm{wt},b]\) 正是区分 window-\(6\) boundary 横截所需的极小交换放大。
+\end{theorem}
+\begin{proof}
+由定理 \ref{thm:conclusion-window6-boundary-radial-defect}，\(\CC[\mathrm{wt},b]\) 的六个原子正是所列六个水平集，故
+\[
+\dim_{\CC}\CC[\mathrm{wt},b]=6.
+\]
+
+反之，任意有限维交换半单代数的维数等于其 primitive idempotents 的个数。若 \(B\) 含 \(\mathcal A_{\mathrm{rad}}\)，则其原子必须细分重量壳层 \(\mathrm{wt}=0,1,2,3\)；若再要求 \(B\) 能把 \(\mathrm{wt}=2,3\) 两层中的 boundary/cyclic 两部分区分开，则上述六个集合都必须是 \(B\) 的原子划分的并，而不能再合并。因而 \(B\) 至少需要六个 primitive idempotents，即
+\[
+\dim_{\CC}B\ge 6.
+\]
+证毕。
+\end{proof}
+
+\begin{theorem}[window-\texorpdfstring{$6$}{6} 同标签关系的无边、混奇与长程几何]\label{thm:conclusion-window6-samelabel-edgeless-oddmixed-longrange}
+定义同标签 Hamming 枚举多项式
+\[
+\mathcal A_6(z)
+:=
+\sum_{\substack{\omega,\eta\in\Omega_6\\ F_6(\omega)=F_6(\eta)}}z^{d_H(\omega,\eta)},
+\]
+以及无序同标签距离计数
+\[
+E_k:=\#\bigl\{\{\omega,\eta\}\subset \Omega_6:\ F_6(\omega)=F_6(\eta),\ d_H(\omega,\eta)=k\bigr\}
+\qquad (1\le k\le 6).
+\]
+则
+\[
+\mathcal A_6(z)=64+32z^2+32z^3+56z^4+24z^5+4z^6,
+\]
+并且
+\[
+(E_1,E_2,E_3,E_4,E_5,E_6)=(0,16,16,28,12,2).
+\]
+于是同时成立：
+\begin{enumerate}
+\normalfont
+  \item \(E_1=0\)，即任意单比特翻转都必离开原纤维；
+  \item \(E_3,E_5>0\)，故同标签关系并非 parity 类；
+  \item 在全部非平凡同标签对上，平均 Hamming 距离恰为
+  \[
+  \bar d
+  =
+  \frac{\sum_{k=1}^6 kE_k}{\sum_{k=1}^6 E_k}
+  =
+  \frac{132}{37}
+  >
+  3.
+  \]
+\end{enumerate}
+因此，window-\(6\) 的同标签几何是一种严格的“边独立、奇距混合、长程粘连”有限等价关系，而不是任何局域码型的退化像。
+\end{theorem}
+\begin{proof}
+前两式分别由定理 \ref{thm:conclusion-window6-samelabel-hamming-enumerator} 与推论 \ref{cor:conclusion-window6-edge-separation-antipodal-residue} 给出。
+
+对平均距离，直接计算得
+\[
+\sum_{k=1}^6E_k=16+16+28+12+2=74,
+\]
+\[
+\sum_{k=1}^6kE_k
+=
+2\cdot 16+3\cdot 16+4\cdot 28+5\cdot 12+6\cdot 2
+=
+264.
+\]
+故
+\[
+\bar d=\frac{264}{74}=\frac{132}{37}>3.
+\]
+证毕。
+\end{proof}
+
+\begin{theorem}[window-\texorpdfstring{$6$}{6} 稳定概率的超公平再入极小值]\label{thm:conclusion-window6-superfair-reentrant-minimum}
+设
+\[
+P_S(p)=1-6p+\frac{31}{2}p^2-\frac{43}{2}p^3+\frac{139}{8}p^4-\frac{63}{8}p^5+\frac{25}{16}p^6
+\]
+为独立位翻转概率 \(p\) 下的稳定概率，并记
+\[
+A_k:=\PP(S\mid K=k),
+\qquad
+K=d_H(W,W^{\mathrm f}).
+\]
+则
+\[
+(A_0,A_1,A_2,A_3,A_4,A_5,A_6)
+=
+\left(
+1,\,
+0,\,
+\frac1{30},\,
+\frac1{40},\,
+\frac7{120},\,
+\frac1{16},\,
+\frac1{16}
+\right).
+\]
+特别地，
+\[
+A_5=A_6=\frac1{16},
+\]
+故 Hamming 尾部出现严格平台。另一方面，\(P_S\) 在 \([0,1]\) 上存在唯一严格极小点
+\[
+p_*\approx 0.5778453100834101>\frac12,
+\]
+且
+\[
+P_S(p_*)\approx 0.0481324504724345
+<
+P_S\!\left(\frac12\right)=\frac{53}{1024}
+<
+P_S(1)=\frac1{16}.
+\]
+因此，对 window-\(6\) 而言，最具破坏性的噪声既不是完全翻转，也不是公平硬币，而是严格位于 \((1/2,1)\) 内部的一点；稳定性在高噪尾部发生真实再入。
+\end{theorem}
+\begin{proof}
+条件保持率谱由定理 \ref{thm:conclusion-window6-noise-local-fragility-high-order-return} 给出，而尾部平台 \(A_5=A_6=\frac1{16}\) 则正是推论 \ref{cor:conclusion-window6-hamming-tail-twolevel-platform} 的内容。
+
+至于极小值结构，定理 \ref{thm:conclusion-window6-stability-probability-unique-internal-minimum} 已证明：\(P_S\) 在 \([0,1]\) 上存在唯一严格极小点 \(p_*\in(0,1)\)，并给出其数值
+\[
+p_*\approx 0.5778453100834101,
+\qquad
+P_S(p_*)\approx 0.0481324504724345.
+\]
+又
+\[
+P_S\!\left(\frac12\right)=\frac{53}{1024},
+\qquad
+P_S(1)=\frac1{16},
+\]
+且二者均严格大于 \(P_S(p_*)\)。证毕。
+\end{proof}
+
+\begin{theorem}[三域类函数空间的 Hoeffding--Chebotarev 正交分层]\label{thm:conclusion-leyang-three-domain-hoeffding-chebotarev-stratification}
+设
+\[
+\mathscr C_{10}:=\mathrm{Cl}(S_{10}),
+\qquad
+\mathscr C_3:=\mathrm{Cl}(S_3),
+\qquad
+\mathscr C_4:=\mathrm{Cl}(S_4\times C_2),
+\]
+并赋予由三域 Frobenius 张量乘积密度诱导的 Hilbert 结构，记
+\[
+\mathscr H
+:=
+\mathscr C_{10}\otimes \mathscr C_3\otimes \mathscr C_4.
+\]
+记各因子的中心化子空间为
+\[
+\mathscr C_{10}^\circ,\qquad
+\mathscr C_3^\circ,\qquad
+\mathscr C_4^\circ.
+\]
+则有严格正交分解
+\[
+\mathscr H
+=
+\CC 1
+\oplus
+\mathscr C_{10}^\circ
+\oplus
+\mathscr C_3^\circ
+\oplus
+\mathscr C_4^\circ
+\oplus
+(\mathscr C_{10}^\circ\otimes \mathscr C_3^\circ)
+\oplus
+(\mathscr C_{10}^\circ\otimes \mathscr C_4^\circ)
+\oplus
+(\mathscr C_3^\circ\otimes \mathscr C_4^\circ)
+\oplus
+(\mathscr C_{10}^\circ\otimes \mathscr C_3^\circ\otimes \mathscr C_4^\circ).
+\]
+其中各层维数分别为
+\[
+1,\qquad
+52,\qquad
+469,\qquad
+738,
+\]
+更具体地，
+\[
+52=41+2+9,
+\qquad
+469=41\cdot 2+41\cdot 9+2\cdot 9,
+\qquad
+738=41\cdot 2\cdot 9.
+\]
+因此，三域 Chebotarev 结构不仅在 mixed cumulants 上块对角，而且在整个类函数 Hilbert 空间上给出一个精确的 Hoeffding--ANOVA 分层。
+\end{theorem}
+\begin{proof}
+由定理 \ref{thm:conclusion-leyang-three-domain-frobenius-tensor-density}，三域 Frobenius 指纹在类函数层面形成严格张量乘积测度；而推论 \ref{cor:conclusion-leyang-three-domain-conditional-invariance-cumulant-vanish} 则说明所有跨两个及以上因子的 mixed cumulants 全部消失。于是 \(\mathscr H\) 作为有限维 Hilbert 空间，正是三个类函数空间的 Hilbert 张量积，并带有标准的 centered/uncentered Hoeffding 分解。
+
+另一方面，
+\[
+\dim \mathscr C_{10}=p(10)=42,
+\qquad
+\dim \mathscr C_3=3,
+\qquad
+\dim \mathscr C_4=\dim \mathrm{Cl}(S_4)\cdot \dim \mathrm{Cl}(C_2)=5\cdot 2=10.
+\]
+故
+\[
+\dim \mathscr C_{10}^\circ=41,
+\qquad
+\dim \mathscr C_3^\circ=2,
+\qquad
+\dim \mathscr C_4^\circ=9.
+\]
+于是，一阶层总维数为
+\[
+41+2+9=52,
+\]
+二阶层总维数为
+\[
+41\cdot 2+41\cdot 9+2\cdot 9=469,
+\]
+三阶层维数为
+\[
+41\cdot 2\cdot 9=738.
+\]
+证毕。
+\end{proof}
+
+\begin{corollary}[审计偶数窗的 Cassini 整锁定]\label{cor:conclusion-audited-even-window-cassini-lock}
+在审计偶数窗
+\[
+m\in\{6,8,10,12\}
+\]
+上，记最小退化层规模
+\[
+M_m:=|\mathcal S_{m,d_{\min}(m)}|,
+\]
+更深两层的极大纤维尺度
+\[
+L_m:=D_{2m-2},
+\]
+以及可见稳定词总数 \(|X_m|\)。则
+\[
+(M_m,L_m,|X_m|)=(F_m,F_{m+1},F_{m+2})
+\]
+蕴含精确 Cassini 锁定
+\[
+L_m^2-M_m|X_m|=1.
+\]
+等价地，
+\[
+\det
+\begin{pmatrix}
+M_m & L_m\\
+L_m & |X_m|
+\end{pmatrix}
+=-1.
+\]
+因此，window-\(6\) 及其相邻审计偶窗中的“最小层--更深极大纤维--全体稳定词”三元组，不仅满足黄金比极限，而且满足严格的整数 unimodular 锁定。
+\end{corollary}
+\begin{proof}
+由定理 \ref{thm:conclusion-audited-even-window-fibonacci-adjacent-odds}，
+\[
+M_m=F_m,\qquad L_m=F_{m+1},\qquad |X_m|=F_{m+2}.
+\]
+对偶数 \(m\)，Cassini 恒等式给出
+\[
+F_{m+1}^2-F_mF_{m+2}=(-1)^m=1.
+\]
+代入即得
+\[
+L_m^2-M_m|X_m|=1.
+\]
+矩阵行列式公式只是其等价重写。证毕。
+\end{proof}
+
+\endinput

--- a/theory/2026_golden_ratio_driven_scan_projection_generation_recursive_emergence/sections/body/conclusion/subsec__conclusion-window6-foldpi-endpoint-binaryescort-minimal-hosts.tex
+++ b/theory/2026_golden_ratio_driven_scan_projection_generation_recursive_emergence/sections/body/conclusion/subsec__conclusion-window6-foldpi-endpoint-binaryescort-minimal-hosts.tex
@@ -1,0 +1,236 @@
+\subsection{window-\texorpdfstring{$6$}{6} 边界 bit、fold-\texorpdfstring{$\pi$}{pi} 纯标量类与 endpoint 最小宿主的不可再压缩性}\label{subsec:conclusion-window6-foldpi-endpoint-binaryescort-minimal-hosts}
+
+沿用小节 \ref{subsec:conclusion-foldbin-stable-k0-faithful-boundary-parity-groupoid}、\ref{subsec:conclusion-window6-homotopy-markov-fullmatrix-rigidity}、\ref{subsec:conclusion-foldgauge-pi-evenzeta-budget-comparison}、\ref{subsec:conclusion-foldgauge-pi-window-accelerator-zeta-koenigs}、\ref{subsec:conclusion-foldgauge-pi-zero-radius-external-obstruction}、\ref{subsec:conclusion-endpoint-stopping-halfentropy-laguerre-register-rigidity}、\ref{subsec:conclusion-maxfiber-freezing-capacity-entropy-separation}、\ref{subsec:conclusion-parameterblind-binaryclosure-halfentropy-ledger-obstruction}、\ref{subsec:conclusion-freezing-capacity-samplepattern-audit-register-trisplitting} 与小节 \ref{subsec:conclusion-window6-residual-budget-freezing-golden-constants} 的记号。前述链条已经分别给出：window-\(6\) boundary parity 的 \(0/1/3\) 通道律与 \(18\)-维 residual quotient、完整纤维划分的群胚型宿主、fold-\(\pi\) 标量通道的零半径 Bernoulli 奇层芽与唯一有限窗加速塔、临界最优核的单本征对/单分母全局反演、停止实验的一位充分化、以及 binary uplift 与 escort 温度轴在 Bernoulli 边界和冻结区上的两次塌缩。把这些对象并置后，可以再压出如下六条终端综合命题。
+
+\begin{theorem}[window-\texorpdfstring{$6$}{6} boundary parity 的一几何位、十八维 hidden quotient 与群胚承载分裂]\label{thm:conclusion-window6-boundary-onebit-eighteenquotient-groupoid-splitting}
+在 window-\(6\) 上，boundary parity
+\[
+P_6\cong (\ZZ/2\ZZ)^3
+\]
+同时满足：
+\begin{enumerate}
+  \item 强局域几何只保留唯一对角 bit
+  \[
+  P_6^{\mathrm{geo}}=\langle(1,1,1)\rangle\cong \ZZ/2\ZZ,
+  \qquad
+  P_6/P_6^{\mathrm{geo}}\cong (\ZZ/2\ZZ)^2;
+  \]
+  \item 剥离 boundary parity 直和后，hidden anomaly quotient 恰为
+  \[
+  (G_6^{\mathrm{bin}})^{\mathrm{ab}}/C_{\partial}\cong (\ZZ/2\ZZ)^{18},
+  \]
+  且最小忠实残余预算正好为 \(18\)；
+  \item 边界升格扇区上虽然保留一个正则 \(\ZZ_6\)-torsor，但该自由对称不能延拓为全窗口上的自由有限群轨道；
+  \item 完整 bin-fold 纤维划分既不能由自由有限群作用的轨道给出，也不能由阿贝尔群仿射陪集给出，其最小自然承载对象只能是群胚型半单对象。
+\end{enumerate}
+因此，protocol-free 的跨尺度搬运、强局域几何可见性与全局自由对称，在 window-\(6\) 上不能被同一有限 torsion 通道同时压缩承载。
+\end{theorem}
+\begin{proof}
+第一条正是定理 \ref{thm:conclusion-window6-boundary-parity-zero-one-three-law} 与推论 \ref{cor:conclusion-window6-boundary-two-residual-bits-nongeometric-nonrational} 的合并表述：有理连续包络对全部 \(P_6\) 失显，而强局域 geometric uplift 仅保留对角 bit。
+
+第二条由定理 \ref{thm:conclusion-window6-boundary-quotient-cyclic-cardinality} 与推论 \ref{cor:conclusion-window6-minimal-faithful-residual-budget-18} 立即得到：剥离 boundary sheet parity 以后，残余异常账本的最小忠实维数恰为 \(18\)。
+
+第三条正是定理 \ref{thm:conclusion-window6-boundary-z6-torsor-local-global-mismatch} 的内容：边界升格上存在正则 \(\ZZ_6\)-torsor，但这一自由对称不存在向全窗口的自由轨道延拓。
+
+第四条由定理 \ref{thm:conclusion-window6-groupoid-rather-than-free-quotient} 给出：window-\(6\) 的完整折叠等价关系既不能来自自由有限群轨道，也不能来自阿贝尔仿射陪集，因此其最小自然宿主必为群胚型而非主群型对象。四条并置即得末句。证毕。
+\end{proof}
+
+\begin{conjecture}[hidden anomaly quotient 到端点奇异层的唯一 transgression]\label{conj:conclusion-window6-hidden-anomaly-quotient-endpoint-transgression}
+记
+\[
+\mathfrak H_6:=(G_6^{\mathrm{bin}})^{\mathrm{ab}}/C_{\partial}\cong (\ZZ/2\ZZ)^{18}.
+\]
+则应存在唯一自然映射
+\[
+\operatorname{tr}_{\partial}:\mathfrak H_6\longrightarrow E_{\partial}^{\mathrm{sing}}
+\]
+满足：
+\begin{enumerate}
+  \item \(\ker(\operatorname{tr}_{\partial})\) 恰刻画所有“在 hidden anomaly ledger 中非平凡、但在端点奇异层仍不可见”的类；
+  \item \(\operatorname{im}(\operatorname{tr}_{\partial})\) 恰是端点奇异层中不能由可见 modulus、interior-zero 轴与有限 \(2\)-主账本解释的最小外置部分；
+  \item \(\operatorname{tr}_{\partial}=0\) 当且仅当边界审计已经可由“模长轴 \(+\) 盘内零点轴 \(+\) 有限 \(2\)-主异常账本”闭合，而不再需要额外实轴。
+\end{enumerate}
+\end{conjecture}
+\begin{proof}[论据]
+定理 \ref{thm:conclusion-window6-boundary-onebit-eighteenquotient-groupoid-splitting} 已经把 boundary 可几何化的部分压缩到唯一对角 bit，并把 residual anomaly quotient 精确固定为 \(18\) 维 \(2\)-挠对象。另一方面，定理 \ref{thm:conclusion-boundary-faithful-carriers-double-host-splitting} 说明：一切若欲 faithful 地同时承载几何边界复杂度与 prime-log 校准边界流的宿主，都必强制分裂为有限几何宿主与可数算术宿主的双层结构。因而，从 hidden torsion quotient 到端点实奇异层的桥不可能再由已几何化的一位 boundary bit 承担，只能来自上述 \(18\)-维 residual quotient。把这两条刚性拼接起来，便得到该 transgression 猜想的自然形式。证毕。
+\end{proof}
+
+\begin{theorem}[fold-\texorpdfstring{$\pi$}{pi} 纯标量普适类的四重排他性]\label{thm:conclusion-foldgauge-pi-purescalar-universality-quadrifurcation}
+凡与 fold-\(\pi\) 属于同一 project-compatible 纯标量普适类的 \(\pi\)-通道，必同时满足下列四条刚性：
+\begin{enumerate}
+  \item 其误差 germ 属于零收敛半径的奇次 Bernoulli 形式芽，而非任何正半径解析局部模型；
+  \item 其局部正规形属于非零乘子的 Koenigs 型，而不属于 AGM/Gauss--Salamin 的超吸引 B\"ottcher 型；
+  \item 其全部有限窗最优加速器都必须来自奇层消元多项式塔 \(P_R(T)\)；
+  \item 其任何远位可寻址 lift 都必须支付严格正的线性地址率。
+\end{enumerate}
+因此，Borwein 型模函数加速、Ramanujan Machine 型 contiguous \({}_2F_1\) 比值、BBP/Bellard/spigot 型尾核以及 Buffon 型随机反演，分别在局部解析正规形、全阶渐近类与资源标度上被严格排除在该纯标量普适类之外。
+\end{theorem}
+\begin{proof}
+第一条正是定理 \ref{thm:conclusion-foldgauge-pi-zero-radius-odd-germ} 的内容：fold-\(\pi\) 误差并不来自任何正半径解析 germ，而是一条真正的零半径奇层形式芽。
+
+第二条由定理 \ref{thm:conclusion-foldgauge-pi-koenigs-vs-agm-nonconjugacy} 给出：fold-gauge 误差芽属于非零乘子的 Koenigs 型，而 AGM/Gauss--Salamin 误差芽属于乘子为 \(0\) 的 B\"ottcher 型，因此二者不可能局部解析共轭。
+
+第三条由定理 \ref{thm:conclusion-foldgauge-pi-affine-log-accelerator-uniqueness} 给出：在固定窗仿射对数类中，达到 \(q^{(2R+1)m}\) 误差阶的加速器唯一存在，且恰为 \(P_R(T)\) 所定义的奇层消元算子。
+
+第四条由命题 \ref{prop:conclusion-foldgauge-pi-bbp-hex-address-rate} 与定理 \ref{thm:conclusion-side-info-length-lower-bound} 的 fold-\(\pi\) 专门化给出：任何远位可寻址 lift 都必须支付严格正的线性地址率。
+
+于是，Borwein 型局部解析核被定理 \ref{thm:conclusion-foldgauge-pi-borwein-local-analytic-obstruction} 排除，Ramanujan Machine 型超几何连分式被定理 \ref{thm:conclusion-foldgauge-pi-ramanujan-machine-hypergeometric-obstruction} 排除，BBP/Bellard/spigot 尾核被定理 \ref{thm:conclusion-foldgauge-pi-bbp-tail-algebraic-exponential-obstruction} 排除，而 Buffon 型随机反演则由定理 \ref{thm:conclusion-foldgauge-pi-buffon-quadratic-exponential-cost} 强制支付二次指数样本代价。证毕。
+\end{proof}
+
+\begin{theorem}[fold-\texorpdfstring{$\pi$}{pi} 的唯一有限窗正则加速塔与单标量自校准]\label{thm:conclusion-foldgauge-pi-selfcalibrated-accelerator-tower-uniqueness}
+记
+\[
+q=\frac{\varphi}{2},
+\qquad
+D_2^\infty=\frac{2\varphi-3}{5},
+\qquad
+K_\varphi:=\prod_{r\ge 1}\frac{1+q^{2r-1}}{1-q^{2r-1}}.
+\]
+则对每个 \(R\ge 1\)：
+\begin{enumerate}
+  \item 存在唯一多项式
+  \[
+  P_R(z)=\prod_{r=1}^{R}\frac{z-q^{2r-1}}{1-q^{2r-1}}
+  \]
+  使长度 \(R+1\) 的连续窗口 \((C_m,\dots,C_{m+R})\) 在固定窗仿射对数类中恰好消去前 \(R\) 个奇层，并把主误差阶提升到 \(q^{(2R+1)m}\)；
+  \item 任意长度小于 \(R+1\) 的连续窗口都不可能达到同阶误差；
+  \item 全部最优加速器的 \(\ell^1\)-条件数统一受同一有限常数 \(K_\varphi\) 控制；
+  \item 单一标量 \(D_2^\infty\) 已唯一决定 \(\varphi\)、\(q\) 与整条 \(P_R\)-塔；
+  \item 第 \(r\) 个偶值 \(\zeta(2r)\) 可由长度恰为 \(r\) 的连续窗口
+  \[
+  (C_m,\dots,C_{m+r-1})
+  \]
+  以统一误差 \(O(q^{2m})\) 直接抽取。
+\end{enumerate}
+因此，fold-\(\pi\) 的加速机制不是任意窗口工程，而是一条唯一、最短、稳定且可由单一 \(\chi^2\) 极限常数自校准的内生算子塔。
+\end{theorem}
+\begin{proof}
+第一、二条分别正是定理 \ref{thm:conclusion-foldgauge-pi-oddlayer-annihilation-hierarchy} 与定理 \ref{thm:conclusion-foldgauge-pi-affine-log-accelerator-uniqueness} 的直接内容：\(P_R(T)\) 恰好湮灭前 \(R\) 个奇层，而短窗因次数不足不可能同时消去这些模态。
+
+第三条由定理 \ref{thm:conclusion-foldgauge-pi-accelerator-uniform-conditioning} 给出，其中 \(\ell^1\)-条件数的闭式乘积收敛到一有限常数。第四条由定理 \ref{thm:conclusion-foldgauge-pi-selfcalibrated-minimal-window} 给出：单一标量 \(D_2^\infty\) 已足以反演 \(\varphi\) 与 \(q\)，从而全部 \(P_R\) 都可显式自校准。
+
+最后，第五条正是定理 \ref{thm:conclusion-foldgauge-even-zeta-finite-window-extraction} 的结论：\(\zeta(2r)\) 可由长度恰为 \(r\) 的连续窗口以统一 \(O(q^{2m})\) 误差直接抽取。证毕。
+\end{proof}
+
+\begin{theorem}[endpoint 侧四种极小宿主的不可再压缩性]\label{thm:conclusion-endpoint-four-minimal-hosts-noncompressible}
+在 endpoint/stopping/critical-kernel 支链上，以下四类极小宿主分别独立闭合各自的全局几何：
+\begin{enumerate}
+  \item 任一单层张量伪行列式 \(\Pi_k(w)\) 已严格单调决定 \(H_{1/2}(w)\)，并从而决定整座临界伪行列式张量塔；
+  \item 任一单一非平凡本征对 \((\lambda,v)\) 已足以恢复 \(w\) 并反演整个 threshold atlas；
+  \item 任一单目标 Laguerre 分母 \(D_y\) 已足以恢复 \(w\)、\(K_\delta^\ast\)、全部 hitting laws、全部 resolvent 矩元与全部 separation 曲线；
+  \item 完整停止样本 \(W_T\) 在推断论上严格塌缩为“一位证据 \(S_T\) \(+\) ancillary 时间 \(\tau_T\)”。
+\end{enumerate}
+同时，双端点失真几何不存在任何统一的固定有限整数碰撞矩坐标。因而，在项目稿当前的 faithful 证书体系中，半熵标量、本征对证书、单目标分母证书与一位停止证据分属彼此不同的最小宿主层，不能被重新压回同一固定有限统计坐标。
+\end{theorem}
+\begin{proof}
+第一条由定理 \ref{thm:conclusion-endpoint-halfentropy-pdet-tower-rigidity} 给出，其中单层值已严格恢复 \(H_{1/2}(w)\)，并进而恢复整个张量塔。第二条正是定理 \ref{thm:conclusion-endpoint-single-eigenpair-inverts-threshold-atlas}。第三条正是定理 \ref{thm:conclusion-endpoint-one-target-laguerre-global-certificate}。第四条则由定理 \ref{thm:conclusion-endpoint-stopping-onebit-ancillary-factorization} 给出。
+
+另一方面，定理 \ref{thm:conclusion-endpoint-no-unified-finite-integer-moment-coordinate} 已经说明：对任意固定有限族整数碰撞矩，都可构造在零速率端点 jet 上完全一致、却在小失真生成元上立即分裂的分布对。因此这些极小宿主无法再被压回同一个固定有限统计坐标。证毕。
+\end{proof}
+
+\begin{theorem}[window-\texorpdfstring{$6$}{6} 的 binary uplift 是严格 Schur--均匀化器]\label{thm:conclusion-window6-binary-uplift-strict-schur-uniformizer}
+在 \(m=6\) 上，binary uplift 的退化谱具有刚性的后缀柱面三裂分
+\[
+S_{6,2}=X_4,01,
+\qquad
+S_{6,3}=(X_3\setminus\{\texttt{000}\}),010,
+\qquad
+S_{6,4}=X_4,00\sqcup\{\texttt{000010}\}.
+\]
+并且其降序纤维谱严格被 ordinary Fold 的降序纤维谱主序：
+\[
+\mathbf d_6^{\mathrm{ord},\downarrow}\succ \mathbf d_6^{\mathrm{bin},\downarrow}.
+\]
+由此立刻推出：
+\begin{enumerate}
+  \item 对任意严格 Schur--凹对称泛函 \(\mathcal H\)，都有
+  \[
+  \mathcal H(\widehat{\mathbf d}_6^{\mathrm{bin}})
+  >
+  \mathcal H(\widehat{\mathbf d}_6^{\mathrm{ord}});
+  \]
+  特别地，全部 Rényi 熵与 Shannon 熵在 binary uplift 下严格增大；
+  \item 连续容量曲线逐点改善：
+  \[
+  \mathcal C_6^{\mathrm{bin}}(T)\ge \mathcal C_6^{\mathrm{ord}}(T)\qquad(T\ge 0);
+  \]
+  \item 二阶断点测度从 ordinary 的 \(5\) 个断点压缩为 binary 的 \(3\) 个断点；
+  \item 可见比特严格增加，而归一化二阶碰撞指纹严格下降：
+  \[
+  I_6^{\mathrm{bin}}-I_6^{\mathrm{ord}}>0,
+  \qquad
+  C_{\mathrm{col}}^{\mathrm{ord}}(6)-C_{\mathrm{col}}^{\mathrm{bin}}(6)=\frac{21}{512}.
+  \]
+\end{enumerate}
+因此，binary uplift 并非只把最大纤维由 \(5\) 压到 \(4\)；它在固定总质量 \(64\) 与固定可见类型数 \(21\) 下，完成了一次严格的 Schur--均匀化。
+\end{theorem}
+\begin{proof}
+后缀柱面三裂分正是定理 \ref{thm:conclusion-window6-binary-suffix-cylinder-trichotomy} 的内容。严格主序关系则由定理 \ref{thm:conclusion-window6-ordinary-binary-strict-majorization} 给出。
+
+于是第一、二、三条都由推论 \ref{cor:conclusion-window6-majorization-entropy-capacity-order} 立即推出：主序在全部严格 Schur--凹泛函上给出严格熵增，并把连续容量曲线逐点抬高，同时把二阶断点支撑从 \(5\) 个压缩到 \(3\) 个。
+
+最后一条正是命题 \ref{prop:conclusion-window6-visible-bits-collision-drop} 的显式闭式。证毕。
+\end{proof}
+
+\begin{theorem}[escort 温度轴先塌缩为 Bernoulli 边界模型，再塌缩为冻结基态简并度]\label{thm:conclusion-escort-temperature-bernoulli-then-frozen-degeneracy}
+首先，对 bin-fold escort 族 \(\pi_{m,q}\)，任意 \(p,q\ge 0\) 与任意凸函数 \(\Phi\)（\(\Phi(1)=0\)）都满足
+\[
+\lim_{m\to\infty}D_\Phi(\pi_{m,q}\Vert \pi_{m,p})
+=
+\theta(p)\Phi\!\left(\frac{\theta(q)}{\theta(p)}\right)
++
+\bigl(1-\theta(p)\bigr)\Phi\!\left(\frac{1-\theta(q)}{1-\theta(p)}\right),
+\qquad
+\theta(q)=\frac{1}{1+\varphi^{q+1}}.
+\]
+因此，全部 bin-fold escort 温度间几何在极限中统一塌缩为同一个 Bernoulli 两点模型。
+
+其次，在一般冻结区 \(a>a_{\mathrm c}\) 中，escort 分布 \(\pi_{m,a}\) 对最大纤维集合 \(A_m^{\max}\) 指数集中，并满足：
+\[
+\lim_{m\to\infty}\frac1m H_s(\pi_{m,a})=g_\ast
+\qquad (s\in[1,\infty]),
+\]
+\[
+\|\pi_{m,a}-U_m^{\max}\|_{\mathrm{TV}}
+=
+1-\pi_{m,a}(A_m^{\max})
+\le
+e^{-m\Delta(a)+o(m)}.
+\]
+故温度轴并不会在高维内部几何上持续展开；它先因子化为一个 Bernoulli 边界参数 \(\theta(q)\)，再在冻结区进一步压缩为单一基态简并指数 \(g_\ast\)。
+\end{theorem}
+\begin{proof}
+第一部分正是定理 \ref{thm:conclusion-escort-two-state-closure} 的 \(\Phi\)-散度版本：bin-fold escort 温度族的全部相对几何极限都由末位变量 \(w_m\in\{0,1\}\) 所承载，并闭合为一个 Bernoulli 两点模型。
+
+第二部分则由定理 \ref{thm:conclusion-freezing-measure-collapse-all-axes} 直接给出。该定理表明：一旦 \(a>a_{\mathrm c}\)，escort 测度在质量、全部 Rényi/Shannon 熵率与全变差几何上同步塌缩到最大纤维集合上的均匀分布，而所有熵率都收敛到同一常数 \(g_\ast\)。两段并置即得结论。证毕。
+\end{proof}
+
+综上，本轮可压缩为三条新的终端闭链：
+\[
+\text{boundary parity}
+\Longrightarrow
+\text{唯一几何 bit}
+\Longrightarrow
+(\ZZ/2\ZZ)^{18}\text{ residual quotient}
+\Longrightarrow
+\text{群胚型全局宿主};
+\]
+\[
+\text{零半径奇层芽}
+\Longrightarrow
+\text{Koenigs 正规形}
+\Longrightarrow
+\text{唯一有限窗加速塔}
+\Longrightarrow
+\text{单一 \(\chi^2\) 常数自校准};
+\]
+\[
+\text{单层半熵 / 单本征对 / 单目标分母 / 一位停止证据}
+\Longrightarrow
+\text{各自生成整座全局几何}
+\Longrightarrow
+\text{不存在固定有限统计共同上层}.
+\]
+其终态判断是：项目稿在这一分支上真正固定下来的，不是若干彼此平行的常数公式，而是一组彼此不可再压缩的最小宿主。window-\(6\) 的唯一几何 boundary bit、fold-\(\pi\) 的唯一加速多项式塔、临界核的单目标分母与停止实验的一位证据，各自都已足以生成整座全局几何；但这些宿主之间并不存在一个还能把它们再压到同一层的有限共同上层。
+
+\endinput

--- a/theory/2026_golden_ratio_driven_scan_projection_generation_recursive_emergence/sections/body/conclusion/subsec__conclusion-window6-freezing-bridge-primefault-cartan-coupling.tex
+++ b/theory/2026_golden_ratio_driven_scan_projection_generation_recursive_emergence/sections/body/conclusion/subsec__conclusion-window6-freezing-bridge-primefault-cartan-coupling.tex
@@ -1,0 +1,351 @@
+\subsection{window-\texorpdfstring{$6$}{6} 的冻结反相关、boundary 极值桥与奇素 Cartan 耦合}\label{subsec:conclusion-window6-freezing-bridge-primefault-cartan-coupling}
+
+沿用小节 \ref{subsec:conclusion-window6-fixedwindow-shell-escort-discriminant-rigidity}、小节 \ref{subsec:conclusion-window6-cartan-dynamics-green-singleprime-faultline} 与小节 \ref{subsec:conclusion-window6-chiral-bulk-flag-oddprime-rigidity} 的记号，并继续使用正文中关于二点纤维方向谱、仿射纤维分类、edge--flux 局部骨架与 Lie 包络的既有标签。前述链条已经分别固定了：window-\(6\) 的 \(2{:}3{:}4\) 纤维直方图与 escort 壳序、boundary 中心的 dyadic 方向实现、局部/粗粒 odd-prime faultline、canonical \(23\)-线性响应，以及 full edge--flux dynamics 的 \(\mathfrak{sl}_{21}\) 饱和与 \(\mathfrak{so}_{21}\)-orbit 充满性。把这些接口进一步并置后，可再抽出一条此前未被单列的闭链：零温 escort 极限与最大码距扇区严格反相关；boundary 中心只沿唯一一条 Hamming 权 \(5\) 的方向跨接 cyclic/boundary 两侧；odd-prime 数据严格分裂为一个局部临界素数 \(23\) 与一个 coarse 新生素数 \(571\)；而这一对奇素并非附着在某个低秩可见锥上，而是只能出现在已经 Cartan 饱和的 full noncommutative dynamics 之内。
+
+\begin{theorem}[零温冻结与几何极值的严格反相关]\label{thm:conclusion-window6-zero-temp-vs-codegap-anticorrelation}
+对 \(q>0\) 定义 window-\(6\) 的 escort 分布
+\[
+\pi_{6,q}(w):=\frac{d_6(w)^q}{\sum_{x\in X_6}d_6(x)^q},
+\qquad
+w\in X_6,
+\]
+并记
+\[
+E_5:=\{w\in X_6:\ \delta_{\min}(w)=5\}.
+\]
+则有精确闭式
+\[
+\pi_{6,q}(E_5)
+=
+\frac{2^{q+1}}{8\cdot 2^q+4\cdot 3^q+9\cdot 4^q}
+=
+\frac{2}{9}\,2^{-q}(1+o(1)),
+\qquad q\to+\infty.
+\]
+特别地，
+\[
+\pi_{6,q}(E_5)\xrightarrow[q\to+\infty]{}0.
+\]
+另一方面，若
+\[
+S_{6,4}^{\mathrm{pl}}:=\{w\in X_6:\ F_w\cong P\},
+\qquad
+S_{6,4}^{\mathrm{simp}}:=\{w\in X_6:\ F_w\cong \Sigma\},
+\]
+则
+\[
+\pi_{6,q}\longrightarrow
+\frac13\,u_{S_{6,4}^{\mathrm{pl}}}
++\frac23\,u_{S_{6,4}^{\mathrm{simp}}}.
+\]
+因此，window-\(6\) 的零温冻结并不偏向最大内部码距，而是把全部质量压缩到最大多重度层 \(S_{6,4}\) 上；在该锚点上，热力学极值与码距极值严格反相关。
+\end{theorem}
+\begin{proof}
+由推论 \ref{cor:window6-degenerate-shell-affine-splitting}，
+\[
+\#S_{6,2}=8,\qquad \#S_{6,3}=4,\qquad \#S_{6,4}=9,
+\]
+故
+\[
+\sum_{x\in X_6}d_6(x)^q=8\cdot 2^q+4\cdot 3^q+9\cdot 4^q.
+\]
+又由定理 \ref{thm:window6-split-extremal-distance-bridge}，
+\[
+E_5=\{\texttt{010001},\texttt{100001}\},
+\qquad
+\#E_5=2.
+\]
+推论 \ref{cor:window6-heavy-fiber-no-max-distance} 进一步给出：任意 \(d_6(w)\ge 3\) 的纤维都不满足 \(\delta_{\min}(w)=5\)。因此 \(E_5\subseteq S_{6,2}\)，从而
+\[
+\sum_{w\in E_5}d_6(w)^q=2\cdot 2^q.
+\]
+两式相除即得
+\[
+\pi_{6,q}(E_5)=\frac{2^{q+1}}{8\cdot 2^q+4\cdot 3^q+9\cdot 4^q}.
+\]
+把分子分母同除以 \(4^q\)，便得到
+\[
+\pi_{6,q}(E_5)
+=
+\frac{2^{1-q}}{8\cdot 2^{-q}+4\cdot (3/4)^q+9}
+=
+\frac{2}{9}\,2^{-q}(1+o(1)).
+\]
+
+另一方面，\(\pi_{6,q}\) 的零温极限正是推论 \ref{cor:window6-degenerate-shell-affine-splitting} 的 escort 极限公式：
+\[
+\pi_{6,q}\longrightarrow
+\frac13\,u_{S_{6,4}^{\mathrm{pl}}}
+\frac23\,u_{S_{6,4}^{\mathrm{simp}}}.
+\]
+由于 \(E_5\subseteq S_{6,2}\) 而 \(S_{6,2}\cap S_{6,4}=\varnothing\)，故零温极限对 \(E_5\) 赋质量 \(0\)。于是零温冻结与最大码距严格脱耦。证毕。
+\end{proof}
+
+\begin{theorem}[boundary 中心的唯一极值桥方向]\label{thm:conclusion-window6-boundary-center-unique-extremal-bridge}
+记
+\[
+D_{\partial}
+:=
+\Span_{\FF_2}\{\texttt{100010},\texttt{100110},\texttt{111110}\}
+\subset \FF_2^6
+\]
+为 window-\(6\) 的 boundary 中心方向子空间。则：
+\begin{enumerate}
+  \item 三条规范基方向的 Hamming 权分别为 \(2,3,5\)；
+  \item 唯一达到最大 Hamming 权 \(5\) 的方向是
+  \[
+  \xi_\ast:=\texttt{111110};
+  \]
+  \item 恰有两条纤维实现该方向，且精确为
+  \[
+  \{\texttt{010001},\texttt{100001}\};
+  \]
+  其中前者位于 cyclic 扇区，后者位于 boundary 扇区；
+  \item 这两条纤维恰好也是 window-\(6\) 中全部且仅有的 \(\delta_{\min}=5\) 纤维。
+\end{enumerate}
+因此，boundary 中心并非沿多条极值方向向外泄露；其唯一的极值桥严格沿 \(\FF_2\xi_\ast\) 发生，并精确跨接 cyclic/boundary 两侧。
+\end{theorem}
+\begin{proof}
+由推论 \ref{cor:window6-boundary-center-direction-realization}，
+\[
+D_{\partial}
+=
+\Span_{\FF_2}\{\texttt{100010},\texttt{100110},\texttt{111110}\}.
+\]
+三条基向量的 Hamming 权分别为
+\[
+|\texttt{100010}|_{\mathrm H}=2,\qquad
+|\texttt{100110}|_{\mathrm H}=3,\qquad
+|\texttt{111110}|_{\mathrm H}=5,
+\]
+故极大权方向唯一，记为 \(\xi_\ast=\texttt{111110}\)。
+
+再由定理 \ref{thm:window6-split-extremal-distance-bridge}，
+\[
+v(\texttt{010001})=v(\texttt{100001})=\texttt{111110},
+\]
+并且
+\[
+\delta_{\min}(w)=5
+\iff
+w\in\{\texttt{010001},\texttt{100001}\}.
+\]
+其中 \(\texttt{100001}\in X_6^{\mathrm{bdry}}\)，而 \(\texttt{010001}\in X_6^{\mathrm{cyc}}\)。于是 \(\xi_\ast\) 被恰好两条纤维实现，并且这两条实现正好等于全部 split-extremal 纤维。证毕。
+\end{proof}
+
+\begin{theorem}[odd-prime 的仿射--局部--粗粒转译对]\label{thm:conclusion-window6-oddprime-affine-local-coarse-translation}
+定义三个 odd-prime 支撑集
+\[
+\mathcal P_{\mathrm{aff}}
+:=
+\{p\text{ odd prime}:p\mid \mathfrak A_6\},
+\]
+\[
+\mathcal P_{\mathrm{loc}}
+:=
+\{p\text{ odd prime}:p\mid \det(E)\ \text{or}\ p\mid \det(M)\},
+\]
+\[
+\mathcal P_{\mathrm{coarse}}
+:=
+\{p\text{ odd prime}:p\mid \tau(\mathcal G_E)\}.
+\]
+则在 window-\(6\) 上精确有
+\[
+\mathcal P_{\mathrm{aff}}=\{23\},
+\qquad
+\mathcal P_{\mathrm{loc}}=\{3,5,23\},
+\qquad
+\mathcal P_{\mathrm{coarse}}=\{3,571\}.
+\]
+特别地，
+\[
+23\in
+\mathcal P_{\mathrm{aff}}\cap \mathcal P_{\mathrm{loc}}
+\setminus
+\mathcal P_{\mathrm{coarse}},
+\qquad
+571\in
+\mathcal P_{\mathrm{coarse}}
+\setminus
+\mathcal P_{\mathrm{loc}},
+\]
+且这两个差集都是单点集。
+
+因此，window-\(6\) 存在一个严格的 odd-prime 二分机制：\(23\) 是仿射完成与局部响应同时可见、却在 coarse Green 层被抹除的素数；\(571\) 则是 coarse 势论中新生、但在全部局部矩阵审计量中不可见的素数。
+\end{theorem}
+\begin{proof}
+由定理 \ref{thm:window6-affine-completion-volume-4x23}，
+\[
+\mathfrak A_6=92=2^2\cdot 23,
+\]
+故
+\[
+\mathcal P_{\mathrm{aff}}=\{23\}.
+\]
+
+由定理 \ref{thm:conclusion-window6-local-global-prime-faultline}，
+\[
+\det(E)=10350=2\cdot 3^2\cdot 5^2\cdot 23,
+\qquad
+\tau(\mathcal G_E)=123336=2^3\cdot 3^3\cdot 571.
+\]
+因而
+\[
+\{p\text{ odd}:p\mid \det(E)\}=\{3,5,23\},
+\qquad
+\mathcal P_{\mathrm{coarse}}=\{3,571\}.
+\]
+另一方面，由定理 \ref{thm:conclusion-window6-canonical-oddprime-response-line}，
+\[
+\det(M)=-2^{12}\cdot 3^2\cdot 5\cdot 23,
+\]
+故
+\[
+\{p\text{ odd}:p\mid \det(M)\}=\{3,5,23\}.
+\]
+于是
+\[
+\mathcal P_{\mathrm{loc}}=\{3,5,23\}.
+\]
+三式合并即可得到全部结论。证毕。
+\end{proof}
+
+\begin{corollary}[局部临界素数与 coarse 新生素数的严格二分]\label{cor:conclusion-window6-critical-vs-emergent-oddprimes}
+设
+\[
+\mathcal P_{\mathrm{crit}}^{(6)}:=\{23\},
+\qquad
+\mathcal P_{\mathrm{emg}}^{(6)}:=\{571\}.
+\]
+则：
+\begin{enumerate}
+  \item 对任意奇素数 \(p\ge 7\)，有
+  \[
+  \ker(M\bmod p)=0
+  \qquad (p\neq 23),
+  \]
+  而
+  \[
+  \dim_{\FF_{23}}\ker(M\bmod 23)=1;
+  \]
+  因而高特征奇素响应中唯一的 projective 奇点恰是
+  \[
+  \mathbb P(\ell_{23}^{(6)})\cong \mathbb P^0(\FF_{23}).
+  \]
+  \item 素数 \(23\) 属于 affine/local 层而不属于 coarse 层；素数 \(571\) 只出现在 coarse Green 层而不属于任何局部矩阵支撑。
+\end{enumerate}
+换言之，window-\(6\) 的 odd-prime 现象严格裂解为两类互不相交的对象：一个是由唯一模 \(23\) 零响应线承载的局部临界素数，另一个是由 coarse Green 分母承载的全局新生素数。
+\end{corollary}
+\begin{proof}
+第一部分直接由定理 \ref{thm:conclusion-window6-canonical-oddprime-response-line} 给出：对任意
+\[
+p\notin\{2,3,5,23\}
+\]
+都有 \(\ker(M\bmod p)=0\)，而在 \(p=23\) 上存在唯一的一维零响应线
+\[
+\ell_{23}^{(6)}:=\ker(M\bmod 23)\subset \FF_{23}^{21}.
+\]
+当 \(p\ge 7\) 时，只有 \(p=23\) 可能产生非零核，于是其 projectivization 恰是单点。
+
+第二部分只是把定理 \ref{thm:conclusion-window6-oddprime-affine-local-coarse-translation} 中的三层支撑集写成
+\[
+\mathcal P_{\mathrm{crit}}^{(6)}=\mathcal P_{\mathrm{aff}}\cap \mathcal P_{\mathrm{loc}}\setminus \mathcal P_{\mathrm{coarse}}=\{23\},
+\qquad
+\mathcal P_{\mathrm{emg}}^{(6)}=\mathcal P_{\mathrm{coarse}}\setminus \mathcal P_{\mathrm{loc}}=\{571\}.
+\]
+证毕。
+\end{proof}
+
+\begin{theorem}[精确可观测扇区与 Cartan 饱和环境的严格分层]\label{thm:conclusion-window6-observable-sectors-vs-cartan-saturated-ambient}
+记
+\[
+V:=\RR^{X_6},
+\qquad
+\mathfrak k_6:=\Lie\langle [L_i,L_j]:1\le i<j\le 6\rangle,
+\qquad
+\mathfrak g_6:=\Lie\langle L_1,\dots,L_6\rangle.
+\]
+则在 window-\(6\) 上同时成立：
+\begin{enumerate}
+  \item 对任意非空真子集 \(Y\subsetneq X_6\)，坐标投影 \(P_Y\) 都可由 \(L_1,\dots,L_6\) 的有限非交换多项式精确综合；
+  \item 但 \(\RR^Y\) 不可能在全部 \(L_i\) 下同时不变；
+  \item full edge--flux dynamics 不保留任何非零双线性型，也不保留任何非零双线性乘法；
+  \item 有
+  \[
+  \mathfrak k_6=\mathfrak{so}(V),
+  \qquad
+  \mathfrak g_6=\mathfrak{sl}(V),
+  \]
+  并且对任意非零推送方向 \(L_i\) 都有
+  \[
+  U(\mathfrak{so}(V))\cdot L_i=\mathcal S_0(V),
+  \qquad
+  \mathcal S_0(V):=\{T\in\End(V):T^\top=T,\ \operatorname{tr}T=0\}.
+  \]
+\end{enumerate}
+因此，boundary/cyclic、light/heavy、仿射平面型/单纯形型等全部可审计分块虽然都能被精确读出，但都不能提升为自治动力学子系统，更不能提升为内禀代数结构；与此同时，六个对称种子又在 Cartan 分解
+\[
+\mathfrak{sl}(V)=\mathfrak{so}(V)\oplus \mathcal S_0(V)
+\]
+中饱和出全部对称无迹方向。故定理 \ref{thm:conclusion-window6-oddprime-affine-local-coarse-translation} 与推论 \ref{cor:conclusion-window6-critical-vs-emergent-oddprimes} 中的奇素分裂并非附属的数论噪声，而是 full noncommutative dynamics 在 Cartan 饱和环境中的结构性后果。
+\end{theorem}
+\begin{proof}
+第一条正是推论 \ref{cor:window6-exact-projector-synthesis} 的内容。第二条由定理 \ref{thm:window6-edge-flux-commutant-rigidity} 得出：若 \(\RR^Y\) 在全部 \(L_i\) 下不变，则其投影 \(P_Y\) 与全部 \(L_i\) 对易，从而只能是 \(0\) 或 \(I\)，与 \(Y\subsetneq X_6\) 非空真子集矛盾。
+
+第三条由命题 \ref{prop:window6-edge-flux-no-invariant-bilinear-form} 与定理 \ref{thm:window6-edge-flux-no-invariant-binary-product} 直接给出。
+
+第四条中，
+\[
+\mathfrak k_6=\mathfrak{so}(V),
+\qquad
+\mathfrak g_6=\mathfrak{sl}(V)
+\]
+由定理 \ref{thm:window6-push-envelope-certificate-upgrade} 给出；而
+\[
+U(\mathfrak{so}(V))\cdot L_i=\mathcal S_0(V)
+\]
+则是定理 \ref{thm:conclusion-window6-so21-orbit-saturation-sym0} 的精确结论。于是六个对称零迹种子在一次交换子层饱和出全部正交部分之后，又沿 \(\mathfrak{so}(V)\)-orbit 充满整个 \(\mathcal S_0(V)\)。
+
+综上，任何可审计 sector 都只能以 projector-shadow 的形式出现，而不能脱离 ambient full dynamics 自治存在。于是 odd-prime 的局部临界/粗粒新生二分也必须被理解为这一饱和环境中的全局结构效应。证毕。
+\end{proof}
+
+\begin{conjecture}[刚性窗口中的奇素转译--Cartan 耦合律]\label{conj:conclusion-window6-oddprime-translation-cartan-coupling}
+设 \(m\) 为任意刚性窗口，并假定：
+\begin{enumerate}
+  \item 坐标 pushforward 生成元 \(L_1^{(m)},\dots,L_m^{(m)}\) 都是对称零迹算子；
+  \item 第一交换子层已饱和
+  \[
+  \Lie\langle [L_i^{(m)},L_j^{(m)}]:1\le i<j\le m\rangle=\mathfrak{so}(V_m);
+  \]
+  \item 全 Lie 包络满足
+  \[
+  \Lie\langle L_1^{(m)},\dots,L_m^{(m)}\rangle=\mathfrak{sl}(V_m);
+  \]
+  \item 同时存在 affine-completion、local coupling 与 coarse Green 三类 odd-prime 审计接口。
+\end{enumerate}
+则应存在两个互不相交的有限奇素集
+\[
+\mathcal P_{\mathrm{crit}}^{(m)},
+\qquad
+\mathcal P_{\mathrm{emg}}^{(m)}
+\]
+使得：
+\begin{enumerate}
+  \item \(\mathcal P_{\mathrm{crit}}^{(m)}\) 恰等于 affine-completion 与高特征模响应核所共同看见的奇素支撑；
+  \item \(\mathcal P_{\mathrm{emg}}^{(m)}\) 恰等于 coarse Green 层中新出现而在全部局部矩阵审计量中不可见的奇素；
+  \item \(\mathcal P_{\mathrm{crit}}^{(m)}\) 控制 \(\mathcal S_0(V_m)\) 中最小 projective 奇点方向，而 \(\mathcal P_{\mathrm{emg}}^{(m)}\) 控制 coarse 逆算子分母中的新生奇点。
+\end{enumerate}
+在 \(m=6\) 的锚点上，
+\[
+\mathcal P_{\mathrm{crit}}^{(6)}=\{23\},
+\qquad
+\mathcal P_{\mathrm{emg}}^{(6)}=\{571\},
+\]
+正由推论 \ref{cor:conclusion-window6-critical-vs-emergent-oddprimes} 给出。若该猜想成立，则 odd-prime 算术便不再附着于单一矩阵的行列式之上，而会与 Lie--Cartan 饱和机制共同组成一个真正的跨尺度不变量：局部对称种子决定可见奇点的素性，而 coarse 逆算子则把其中一部分抹除并在更高层重生为全新的 coarse 素点。
+\end{conjecture}
+
+\paragraph{统一读法}
+由此，window-\(6\) 的一条此前未被单列的闭链可以压缩如下：零温 escort 极限首先把全部热力学质量压到 \(d=4\) 的最大纤维层上，从而与 \(\delta_{\min}=5\) 的 split-extremal 两点形成严格反相关；这两条极值纤维又并非随机散布，而是沿 boundary 中心唯一的 Hamming 权 \(5\) 方向 \(\texttt{111110}\) 横跨 cyclic/boundary 两侧。进一步地，odd-prime 审计把 \(23\) 与 \(571\) 精确裂解为局部临界与 coarse 新生两类互补角色：前者在 affine completion、局部耦合与模 \(23\) 响应线上同时可见，后者则仅在 coarse Green 分母中首次出现。最后，exact projector synthesis、无自治不变扇区、\(\mathfrak{so}_{21}\) 的交换子饱和与 \(\mathfrak{sl}_{21}\) 的 full Lie 包络共同说明：这些奇素现象并非附着在某个低秩可见 sector 上的偶然算术尾迹，而是由完整非交换动力学在 Cartan 饱和环境中强制产生的结构性断层。
+
+\endinput

--- a/theory/2026_golden_ratio_driven_scan_projection_generation_recursive_emergence/sections/body/conclusion/thm__conclusion-tree-detentropy-cmi-quartic-visibility.tex
+++ b/theory/2026_golden_ratio_driven_scan_projection_generation_recursive_emergence/sections/body/conclusion/thm__conclusion-tree-detentropy-cmi-quartic-visibility.tex
@@ -1,0 +1,308 @@
+\begin{theorem}[基环条件互信息的全局体积熵支配]\label{thm:conclusion-fundamental-cycle-cmi-dominated-by-global-tree-entropy}
+设 \(R\) 为高斯相关矩阵，\(T\) 为任意生成树。定义
+\[
+L_T(R):=
+-\log\det R+\sum_{(i,j)\in T}\log\frac{1}{1-R_{ij}^2}.
+\]
+对任意非树边 \(e=(u,v)\notin T\)，记 \(P_T(u,v)\) 为树上连接 \(u\) 与 \(v\) 的唯一路径，\(S_e:=P_T(u,v)\setminus\{u,v\}\)，并定义基环条件互信息势
+\[
+I_e:=2\,I(X_u;X_v\mid X_{S_e})
+=-\log\bigl(1-\rho_{uv\mid S_e}^2\bigr).
+\]
+则对每个非树边 \(e\notin T\) 都有
+\[
+I_e\le L_T(R).
+\]
+\end{theorem}
+\begin{proof}
+这正是结论 \ref{con:xi-det-entropy-tree-basecycle-cmi-certificate} 的内容。证毕。
+\end{proof}
+
+\begin{corollary}[单条遗漏边的条件相关幅度束缚]\label{cor:conclusion-single-omitted-edge-partial-correlation-budget}
+在定理 \ref{thm:conclusion-fundamental-cycle-cmi-dominated-by-global-tree-entropy} 的设定下，对任意非树边 \(e=(u,v)\notin T\)，都有
+\[
+\rho_{uv\mid S_e}^2\le 1-e^{-L_T(R)}.
+\]
+特别地，
+\[
+|\rho_{uv\mid S_e}|
+\le
+\sqrt{1-e^{-L_T(R)}}
+\le
+\sqrt{L_T(R)}.
+\]
+\end{corollary}
+\begin{proof}
+由定理 \ref{thm:conclusion-fundamental-cycle-cmi-dominated-by-global-tree-entropy}，
+\[
+-\log(1-\rho_{uv\mid S_e}^2)\le L_T(R).
+\]
+指数化并整理即得
+\[
+\rho_{uv\mid S_e}^2\le 1-e^{-L_T(R)}.
+\]
+再用
+\[
+1-e^{-x}\le x\qquad (x\ge 0)
+\]
+即可得到平方根上界。证毕。
+\end{proof}
+
+\begin{corollary}[树近似的统一阈值证书]\label{cor:conclusion-tree-approximation-uniform-threshold-certificate}
+给定阈值 \(\tau\in(0,1)\)。若
+\[
+L_T(R)<-\log(1-\tau^2),
+\]
+则对所有非树边 \(e=(u,v)\notin T\) 都有
+\[
+|\rho_{uv\mid S_e}|<\tau.
+\]
+\end{corollary}
+\begin{proof}
+若存在某条非树边满足 \(|\rho_{uv\mid S_e}|\ge \tau\)，则
+\[
+I_e=-\log(1-\rho_{uv\mid S_e}^2)\ge -\log(1-\tau^2),
+\]
+这与定理 \ref{thm:conclusion-fundamental-cycle-cmi-dominated-by-global-tree-entropy} 矛盾。证毕。
+\end{proof}
+
+\begin{theorem}[链树投影的精确体积亏损公式]\label{thm:conclusion-chain-tree-projection-exact-volume-defect-formula}
+对链树投影 \(R_{\mathrm{MC}}\)，有严格行列式恒等式
+\[
+\det R_{\mathrm{MC}}=\prod_{j=1}^{\kappa-1}\bigl(1-R_{j,j+1}^2\bigr),
+\]
+并且链环熵满足
+\[
+\mathcal L_{\mathrm{chain}}(R)
+=
+-\log\frac{\det R}{\det R_{\mathrm{MC}}}
+=
+-\log\det R+\sum_{j=1}^{\kappa-1}\log\frac{1}{1-R_{j,j+1}^2}.
+\]
+\end{theorem}
+\begin{proof}
+这是结论 \ref{con:xi-det-entropy-markov-volume-ratio} 的直接重述。证毕。
+\end{proof}
+
+\begin{corollary}[固定最近邻数据下的最大体积完成]\label{cor:conclusion-fixed-nearest-neighbor-maximal-volume-completion}
+在固定全部最近邻相关
+\[
+R_{j,j+1}\qquad (1\le j\le \kappa-1)
+\]
+的前提下，任意正定相关矩阵 \(R\) 都满足
+\[
+\det R\le \det R_{\mathrm{MC}}
+=
+\prod_{j=1}^{\kappa-1}\bigl(1-R_{j,j+1}^2\bigr).
+\]
+并且等号成立当且仅当
+\[
+\mathcal L_{\mathrm{chain}}(R)=0,
+\]
+等价地，当且仅当 \(R=R_{\mathrm{MC}}\)。
+\end{corollary}
+\begin{proof}
+由定理 \ref{thm:conclusion-chain-tree-projection-exact-volume-defect-formula}，
+\[
+\mathcal L_{\mathrm{chain}}(R)=-\log\frac{\det R}{\det R_{\mathrm{MC}}}\ge 0,
+\]
+故 \(\det R\le \det R_{\mathrm{MC}}\)。等号与 \(\mathcal L_{\mathrm{chain}}(R)=0\) 显然等价，而
+\[
+\mathcal L_{\mathrm{chain}}(R)=0\iff R=R_{\mathrm{MC}}
+\]
+则由定理 \ref{thm:conclusion-chain-markov-rigidity-fourfold-equivalence} 给出。证毕。
+\end{proof}
+
+\begin{theorem}[链环熵的二阶差分偏离闭式]\label{thm:conclusion-chain-loop-entropy-second-difference-defect-expansion}
+在相邻排序设定下，定义
+\[
+\eta_j:=R_{j-2,j}-R_{j-2,j-1}R_{j-1,j}
+\qquad (3\le j\le \kappa).
+\]
+若整体处于弱相干区，则有一致近似
+\[
+\mathcal L_{\mathrm{chain}}(R)
+=
+\sum_{j=3}^{\kappa}
+\frac{\eta_j^2}
+{(1-R_{j-2,j-1}^2)(1-R_{j-1,j}^2)}
++
+o\!\left(\sum_{j=3}^{\kappa}\eta_j^2\right).
+\]
+\end{theorem}
+\begin{proof}
+这是结论 \ref{con:xi-det-entropy-weak-coherence-chain-q4-law} 的直接表述。证毕。
+\end{proof}
+
+\begin{corollary}[链环熵的最小可见阶在弱相干标度下锁定为四]\label{cor:conclusion-chain-loop-entropy-visible-order-locked-at-four}
+在定理 \ref{thm:conclusion-chain-loop-entropy-second-difference-defect-expansion} 的设定下，若弱相干标度满足
+\[
+\eta_j(\varepsilon)=O(\varepsilon^2)
+\qquad (3\le j\le \kappa),
+\]
+并且至少存在一个 \(j\) 使
+\[
+\eta_j(\varepsilon)\not=o(\varepsilon^2),
+\]
+则
+\[
+\mathcal L_{\mathrm{chain}}(R(\varepsilon))=\Theta(\varepsilon^4).
+\]
+特别地，链环熵不存在二阶或三阶的主导项；其最小可见阶严格锁定为 \(4\)。
+\end{corollary}
+\begin{proof}
+由定理 \ref{thm:conclusion-chain-loop-entropy-second-difference-defect-expansion}，
+\[
+\mathcal L_{\mathrm{chain}}(R(\varepsilon))
+=
+\sum_{j=3}^{\kappa}
+\frac{\eta_j(\varepsilon)^2}
+{(1-R_{j-2,j-1}^2)(1-R_{j-1,j}^2)}
++
+o\!\left(\sum_{j=3}^{\kappa}\eta_j(\varepsilon)^2\right).
+\]
+由假设，
+\[
+\sum_{j=3}^{\kappa}\eta_j(\varepsilon)^2=\Theta(\varepsilon^4),
+\]
+而分母在弱相干区保持 \(1+o(1)\) 的非退化。于是
+\[
+\mathcal L_{\mathrm{chain}}(R(\varepsilon))=\Theta(\varepsilon^4).
+\]
+证毕。
+\end{proof}
+
+\begin{theorem}[等距弱相干相的每步环熵指数律]\label{thm:conclusion-equispaced-weak-coherence-per-step-loop-entropy-law}
+若取等距深度
+\[
+s_j=s_0+(j-1)\Delta,
+\qquad
+\Delta\to\infty,
+\]
+并令 \(\kappa\) 同时增大，则每步链环熵满足
+\[
+\frac{1}{\kappa}\mathcal L_{\mathrm{chain}}(R)\sim \Delta^4 e^{-2\Delta}.
+\]
+\end{theorem}
+\begin{proof}
+这是结论 \ref{con:xi-det-entropy-equispaced-loop-entropy-scaling} 的直接内容。证毕。
+\end{proof}
+
+\begin{corollary}[有界总环熵强迫至少半对数间距]\label{cor:conclusion-bounded-total-loop-entropy-forces-half-log-spacing}
+在定理 \ref{thm:conclusion-equispaced-weak-coherence-per-step-loop-entropy-law} 的等距弱相干族中，若存在常数 \(C>0\) 使
+\[
+\mathcal L_{\mathrm{chain}}(R)\le C
+\]
+对充分大的 \(\kappa\) 都成立，则必有
+\[
+\Delta \ge \frac12\log \kappa + 2\log\log \kappa + O(1)
+\qquad (\kappa\to\infty).
+\]
+\end{corollary}
+\begin{proof}
+由定理 \ref{thm:conclusion-equispaced-weak-coherence-per-step-loop-entropy-law}，
+\[
+\mathcal L_{\mathrm{chain}}(R)\sim \kappa \Delta^4 e^{-2\Delta}.
+\]
+若其有界，则
+\[
+\kappa \Delta^4 e^{-2\Delta}\lesssim 1.
+\]
+取对数得
+\[
+2\Delta \ge \log\kappa + 4\log\Delta + O(1).
+\]
+先由此得到
+\[
+\Delta\ge \frac12\log\kappa + O(\log\log\kappa).
+\]
+再代回 \(\log\Delta=\log\log\kappa+O(1)\)，便得到
+\[
+\Delta \ge \frac12\log \kappa + 2\log\log \kappa + O(1).
+\]
+证毕。
+\end{proof}
+
+\begin{corollary}[次对数间距不可能维持有限体积亏损]\label{cor:conclusion-sublog-spacing-forces-divergent-loop-entropy}
+在定理 \ref{thm:conclusion-equispaced-weak-coherence-per-step-loop-entropy-law} 的等距弱相干族中，若
+\[
+\Delta=o(\log\kappa),
+\]
+则必有
+\[
+\mathcal L_{\mathrm{chain}}(R)\to\infty.
+\]
+\end{corollary}
+\begin{proof}
+由定理 \ref{thm:conclusion-equispaced-weak-coherence-per-step-loop-entropy-law}，
+\[
+\mathcal L_{\mathrm{chain}}(R)\sim \kappa\Delta^4e^{-2\Delta}.
+\]
+于是
+\[
+\log \mathcal L_{\mathrm{chain}}(R)
+=
+\log\kappa+4\log\Delta-2\Delta+o(1).
+\]
+若 \(\Delta=o(\log\kappa)\)，则
+\[
+\log\kappa-2\Delta\to+\infty,
+\]
+从而右端趋于 \(+\infty\)，故 \(\mathcal L_{\mathrm{chain}}(R)\to\infty\)。证毕。
+\end{proof}
+
+\begin{theorem}[链树投影把局部条件相关统一压入单一标量预算]\label{thm:conclusion-chain-tree-single-scalar-budget-controls-local-partial-correlations}
+定义
+\[
+\mathfrak R_{\max}(R):=
+\max_{3\le j\le \kappa}\bigl|\rho_{j-2,j\mid j-1}\bigr|.
+\]
+则有 exact bound
+\[
+\mathfrak R_{\max}(R)^2\le 1-e^{-\mathcal L_{\mathrm{chain}}(R)}.
+\]
+特别地，
+\[
+\mathfrak R_{\max}(R)\le \sqrt{1-e^{-\mathcal L_{\mathrm{chain}}(R)}}\le \sqrt{\mathcal L_{\mathrm{chain}}(R)}.
+\]
+在小环熵制度下，还可写成预算尺度
+\[
+\sqrt{1-e^{-\mathcal L_{\mathrm{chain}}(R)}}=
+\sqrt{\mathcal L_{\mathrm{chain}}(R)}\,\bigl(1+o(1)\bigr).
+\]
+\end{theorem}
+\begin{proof}
+把推论 \ref{cor:conclusion-single-omitted-edge-partial-correlation-budget} 应用于链树 \(T_{\mathrm{chain}}\) 的局部二跳非树边 \((j-2,j)\)，其对应分离集正是 \(\{j-1\}\)，便得到
+\[
+\rho_{j-2,j\mid j-1}^2\le 1-e^{-\mathcal L_{\mathrm{chain}}(R)}
+\qquad (3\le j\le \kappa).
+\]
+对 \(j\) 取最大值得第一式。第二式由
+\[
+1-e^{-x}\le x
+\qquad (x\ge 0)
+\]
+得到。最后一式只需用
+\[
+1-e^{-x}=x+O(x^2)
+\qquad (x\downarrow 0)
+\]
+并取平方根。证毕。
+\end{proof}
+
+\begin{conjecture}[一般树上的基环显影加法性]\label{conj:conclusion-general-tree-fundamental-cycle-quadratic-visibility}
+对任意生成树 \(T\) 与弱相干高斯族，应存在一组规范的 fundamental-cycle defect 坐标 \(\{\eta_e\}_{e\notin T}\)，使
+\[
+L_T(R)
+=
+\sum_{e\notin T}Q_e(\eta_e)
++
+o\!\left(\sum_{e\notin T}\eta_e^2\right),
+\]
+其中每个 \(Q_e\) 都是正定二次型。特别地：
+\begin{enumerate}
+  \item 最小可见阶仍应锁定为 \(4\)；
+  \item 主导二次型族 \(\{Q_e\}\) 只依赖于树上分离集几何，而不依赖于坐标参数化。
+\end{enumerate}
+链树情形已由定理 \ref{thm:conclusion-chain-loop-entropy-second-difference-defect-expansion} 与定理 \ref{thm:conclusion-equispaced-weak-coherence-per-step-loop-entropy-law} 完全实现；而定理 \ref{thm:conclusion-fundamental-cycle-cmi-dominated-by-global-tree-entropy} 又已表明一般树上的每条非树边代价精确由条件互信息给出并受全局环熵支配。这强烈暗示链树中的“二阶差分平方和”并非特例，而是一般树上基环条件互信息的局部二次化极限。
+\end{conjecture}

--- a/theory/2026_golden_ratio_driven_scan_projection_generation_recursive_emergence/sections/body/conclusion/thm__conclusion-window6-boundary-externality-walsh-gap.tex
+++ b/theory/2026_golden_ratio_driven_scan_projection_generation_recursive_emergence/sections/body/conclusion/thm__conclusion-window6-boundary-externality-walsh-gap.tex
@@ -1,0 +1,233 @@
+\begin{theorem}[boundary 的双层遗忘与 \texorpdfstring{$56/97155$}{56/97155} 信息落差]\label{thm:conclusion-window6-boundary-double-forgetfulness-information-gap}
+设
+\[
+\mathcal A_6:=\CC[\mathcal R_6^{\mathrm{bin}}],
+\qquad
+I_{\partial}\subset \mathcal A_6,
+\qquad
+Z_{\partial}\subset Z(G_6^{\mathrm{bin}})\cong (\ZZ/2\ZZ)^8
+\]
+分别为 canonical boundary 的三块理想与三维中心子格。则存在两级严格遗忘：
+\begin{enumerate}
+\normalfont
+  \item 在抽象半单代数层面，
+  \[
+  \bigl|\operatorname{Orb}_{\Aut_{\CC\text{-alg}}(\mathcal A_6)}(I_{\partial})\bigr|
+  =
+  \binom{8}{3}
+  =
+  56;
+  \]
+  \item 在抽象群中心层面，
+  \[
+  \bigl|\operatorname{Orb}_{\Aut(G_6^{\mathrm{bin}})}(Z_{\partial})\bigr|
+  =
+  \binom{8}{3}_2
+  =
+  97155.
+  \]
+\end{enumerate}
+故群层的歧义规模相较于代数层额外放大为
+\[
+\frac{97155}{56}\approx 1734.910714,
+\qquad
+\log_2\frac{97155}{56}\approx 10.7606457023\ \text{bits}.
+\]
+因此，window-\(6\) 的 boundary 并不是一个在抽象层面自然可见的对象；即使已知其在半单代数层对应 dyadic 三块，进一步恢复 canonical 中心三轴仍需额外的组合外置信息。
+\end{theorem}
+\begin{proof}
+第一条正是定理 \ref{thm:conclusion-window6-semisimple-boundary-forgetfulness} 的内容：全部与 \(M_2(\CC)^{\oplus 3}\) 同构的双边理想在
+\[
+\Aut_{\CC\text{-alg}}(\mathcal A_6)
+\]
+作用下构成单一轨道，其大小恰为 \(\binom{8}{3}=56\)。
+
+第二条则由定理 \ref{thm:conclusion-window6-boundary-center-seventeen-bit-barrier} 给出：
+\[
+\bigl|\operatorname{Orb}_{\Aut(G_6^{\mathrm{bin}})}(Z_{\partial})\bigr|
+=
+\binom{8}{3}_2
+=
+97155.
+\]
+两者相除并取二进对数，即得所述额外信息落差。证毕。
+\end{proof}
+
+\begin{corollary}[boundary parity 的三通道律与十五比特外置信息壁垒]\label{cor:conclusion-window6-boundary-threechannel-fifteenbit-externality}
+设 canonical boundary parity 的三类连续/几何通道秩分别为
+\[
+r_{\mathrm{rat}}=0,\qquad
+r_{\mathrm{geo}}=1,\qquad
+r_{\mathrm{faith}}=3.
+\]
+则 faithful boundary parity 的连续实现同时必须满足：
+\begin{enumerate}
+\normalfont
+  \item 任一忠实 torus holonomy 实现至少需要三圆，即最小 torus 秩满足
+  \[
+  \operatorname{rank}T\ge 3;
+  \]
+  \item 即使 visible 根云 pinning 已把残余歧义压到 Klein 四量级，抽象中心恢复 canonical \(Z_{\partial}\) 仍至少需要
+  \[
+  17-2=15
+  \]
+  比特外置信息。
+\end{enumerate}
+因此，window-\(6\) 的 canonical boundary cube 不可能仅由 visible root cloud 的连续极限恢复；它在 faithful 通道中本质上是一份三维 torus 级别的离散外置账本。
+\end{corollary}
+\begin{proof}
+由定理 \ref{thm:conclusion-window6-boundary-parity-zero-one-three-law}，
+\[
+r_{\mathrm{rat}}=0,\qquad r_{\mathrm{geo}}=1,\qquad r_{\mathrm{faith}}=3.
+\]
+其中 \(r_{\mathrm{faith}}=3\) 正说明：若要求忠实地以紧 torus holonomy 实现全部 boundary parity，则最小 torus 秩恰为 \(3\)，故必有 \(\operatorname{rank}T\ge 3\)。
+
+另一方面，定理 \ref{thm:conclusion-window6-boundary-center-seventeen-bit-barrier} 已给出：从抽象群层精确恢复 canonical \(Z_{\partial}\) 至少需要 \(17\) 个二值选择，而 visible 根云 pinning 只剩 Klein 四量级的两位歧义。故额外所需外置信息至少为
+\[
+17-2=15
+\]
+比特。证毕。
+\end{proof}
+
+\begin{theorem}[动力学中心化子的 torus 塌缩]\label{thm:conclusion-window6-dynamical-centralizer-torus-collapse}
+设 \(H\) 为作用于
+\[
+\mathcal H_6=\ell^2(X_6,\pi_6)
+\]
+的连通紧 Lie 群，并满足其表示 \(\rho(H)\) 与 pushforward 动力学算子 \(\mathsf T_6\) 对易。则经适当酉共轭后，
+\[
+\rho(H)\subset U(1)^{21},
+\]
+从而
+\[
+\Lie(\rho(H))
+\]
+必为阿贝尔 Lie 代数。特别地，任何 \(B_3/C_3\)-型非阿贝尔几何机制都不可能作为动力学中心化子的一部分存活。
+\end{theorem}
+\begin{proof}
+这正是推论 \ref{cor:conclusion-window6-torus-phase-only-common-shadow} 的内容。该推论由推论 \ref{cor:conclusion-window6-dynamical-centralizer-toralization} 与定理 \ref{thm:conclusion-window6-dual-lie-realizations-incompatible} 联合推出：一切与 \(\mathsf T_6\) 对易的连通紧 Lie 群都可被酉共轭入 \(U(1)^{21}\)，而同载体上的几何 Lie 结构与动力学 Lie 包络又彼此不相容，故共同连通影像只能退化为环面相位。证毕。
+\end{proof}
+
+\begin{theorem}[最小壳层上 boundary/internal 的 Walsh 能量 \texorpdfstring{$25{:}9$}{25:9} 比]\label{thm:conclusion-window6-minshell-boundary-internal-walsh-energy-ratio}
+在最小二重点壳
+\[
+Y_2\cong (\ZZ/2\ZZ)^3
+\]
+上，定义测度
+\[
+\mu_{\partial}:=\frac13\,\mathbf 1_{X_6^{\mathrm{bdry}}},
+\qquad
+\mu_{\mathrm{int}}:=\frac15\,\mathbf 1_{X_{6,\mathrm{int}}^{(2)}},
+\qquad
+u\equiv 2^{-3}.
+\]
+则碰撞概率满足
+\[
+\operatorname{Col}(\mu_{\partial})=\frac13,
+\qquad
+\operatorname{Col}(\mu_{\mathrm{int}})=\frac15.
+\]
+由此
+\[
+\chi^2(\mu_{\partial}\|u)=\frac53,
+\qquad
+\chi^2(\mu_{\mathrm{int}}\|u)=\frac35.
+\]
+等价地，两者的非平凡 Walsh 总能量之比精确为
+\[
+\frac{\sum_{a\neq 0}\widehat{\mu_{\partial}}(a)^2}
+{\sum_{a\neq 0}\widehat{\mu_{\mathrm{int}}}(a)^2}
+=
+\frac{5/3}{3/5}
+=
+\frac{25}{9}.
+\]
+因此，在最小二重点壳层上，boundary 三点并非 internal 五点的一个稀薄补集；它在 Walsh 频域中精确携带 \(25/9\) 倍的非平凡二阶能量。
+\end{theorem}
+\begin{proof}
+由推论 \ref{cor:conclusion-window6-twofiber-boundary-internal-splitting}，
+\[
+Y_2=X_6^{\mathrm{bdry}}\sqcup X_{6,\mathrm{int}}^{(2)},
+\qquad
+|Y_2|=8,\qquad |X_6^{\mathrm{bdry}}|=3,\qquad |X_{6,\mathrm{int}}^{(2)}|=5.
+\]
+故 \(\mu_{\partial}\) 与 \(\mu_{\mathrm{int}}\) 分别是在三点集与五点集上的均匀分布，于是
+\[
+\operatorname{Col}(\mu_{\partial})=\frac13,
+\qquad
+\operatorname{Col}(\mu_{\mathrm{int}})=\frac15.
+\]
+
+另一方面，由命题 \ref{prop:conclusion-window6-boundary-plancherel-information-identity}，
+\[
+\chi^2(\mu\|u)=8\Bigl(\operatorname{Col}(\mu)-\frac18\Bigr)
+=
+\sum_{a\neq 0}\widehat\mu(a)^2.
+\]
+代入 \(\mu=\mu_{\partial}\) 与 \(\mu=\mu_{\mathrm{int}}\) 分别得到
+\[
+\chi^2(\mu_{\partial}\|u)
+=
+8\left(\frac13-\frac18\right)
+=
+\frac53,
+\]
+\[
+\chi^2(\mu_{\mathrm{int}}\|u)
+=
+8\left(\frac15-\frac18\right)
+=
+\frac35.
+\]
+因此
+\[
+\frac{\sum_{a\neq 0}\widehat{\mu_{\partial}}(a)^2}
+{\sum_{a\neq 0}\widehat{\mu_{\mathrm{int}}}(a)^2}
+=
+\frac{\chi^2(\mu_{\partial}\|u)}{\chi^2(\mu_{\mathrm{int}}\|u)}
+=
+\frac{5/3}{3/5}
+=
+\frac{25}{9}.
+\]
+证毕。
+\end{proof}
+
+\begin{conjecture}[Walsh--Zeckendorf 对偶的归一化唯一实现]\label{conj:conclusion-window6-normalized-walsh-zeckendorf-duality}
+在刚性识别
+\[
+S_{6,2}\cong 13+\{0,1,\dots,7\},
+\qquad
+\widehat Z_{\partial}\cong (\ZZ/2\ZZ)^3
+\]
+下，若进一步固定 boundary 三轴与三条坐标角色的对应，则应存在唯一的归一化酉 Fourier 变换
+\[
+\mathcal W_6:\CC[S_{6,2}]\longrightarrow \CC[\widehat Z_{\partial}]
+\]
+满足：
+\begin{enumerate}
+\normalfont
+  \item \(\CC[X_6^{\mathrm{bdry}}]\) 被送到三条坐标角色张成的子空间；
+  \item \(\CC[X_{6,\mathrm{cyc},2}]\) 被送到五个非坐标 Walsh 模张成的子空间；
+  \item 强局域几何可实现的对角子群
+  \[
+  \langle(1,1,1)\rangle
+  \]
+  在频域上恰对应 \((4+4)\) 的粗粒二分。
+\end{enumerate}
+若此猜想成立，则 window-\(6\) 的最小壳层 \((5+3)\) 裂分、boundary parity 立方体以及 Walsh 模态层并非三套平行字典，而是同一有限 Fourier 对偶的三种坐标化。
+\end{conjecture}
+\begin{proof}[证据]
+定理 \ref{thm:conclusion-window6-residual-threeinterval-terminal-window} 已把
+\[
+S_{6,2}
+\]
+刚性识别为终端 Zeckendorf 窗 \(13+\{0,\dots,7\}\)；定理 \ref{thm:conclusion-window6-minimal-shell-five-three-cleavage} 给出最小壳的 \((5+3)\) 裂分；定理 \ref{thm:conclusion-window6-walsh-spin-duality} 则把最小壳的八点结构与 Walsh--Spin 词典严格对应；而推论 \ref{cor:conclusion-window6-geometric-uplift-four-four-collapse} 又说明强局域几何在频域上留下精确的 \((4+4)\) 粗粒二分。
+
+因此，终端 Zeckendorf 窗、最小壳的 \((5+3)\) 裂分与 boundary parity 角色立方体之间，已经存在一组与有限 Fourier 对偶高度一致的结构线索。尚未闭合的部分仅是显式且归一化唯一的 \(\mathcal W_6\) 构造，故保留为猜想。证毕。
+\end{proof}
+
+\paragraph{统一读法}
+这一组结论表明，window-\(6\) 的 boundary 结构并不是若干彼此松散的附属现象。更严格的情形是：boundary 指示函数先在 radial 壳层代数上分裂出精确的 \(11{:}19\) 正交比例，并由六原子极小交换放大刻画其横截刚性；同标签几何随后表现为无边、混奇与长程三性并存，并在超公平噪声 \(p_*>1/2\) 处达到唯一再入极小值；三域 Frobenius 乘积密度则把 mixed cumulant 的消失提升为整个类函数 Hilbert 空间的 Hoeffding--ANOVA 分层；而在 boundary parity 一侧，抽象半单代数层的 \(56\) 重遗忘与抽象中心层的 \(97155\) 重遗忘共同把 faithful 恢复压成至少 \(15\) 比特的外置信息壁垒，并把 commuting dynamics 的共同连通影像彻底压缩为 \(U(1)^{21}\) 内的 torus phase shadow。由此，boundary 横截刚性、同标签再入噪声、三域正交独立与 canonical boundary cube 的外置恢复，便在同一终端 window-\(6\) 对象上闭合为一条统一结构链。
+
+\endinput

--- a/theory/2026_golden_ratio_driven_scan_projection_generation_recursive_emergence/sections/body/physical_spacetime_skeleton/subsec__physical-spacetime-skeleton-admissible-einstein-domain.tex
+++ b/theory/2026_golden_ratio_driven_scan_projection_generation_recursive_emergence/sections/body/physical_spacetime_skeleton/subsec__physical-spacetime-skeleton-admissible-einstein-domain.tex
@@ -11,7 +11,7 @@
 \subsubsection{有限纤维运输层与时钟搬运}
 
 \begin{definition}[有限纤维运输范畴]\label{def:physical-spacetime-finite-fiber-transport}
-记 \(\mathsf T_{\mathrm{ff}}\) 为由本文既有对象层与更新接口最小生成的有限纤维运输范畴，其对象由以下三类局域数据组成：
+记 \(\mathcal T_{\mathrm{ff}}\) 为由本文既有对象层与更新接口最小生成的有限纤维运输范畴，其对象由以下三类局域数据组成：
 \begin{enumerate}
   \item 各分辨率稳定类型空间 \(X_m\) 及其局域 patch；
   \item 由局部覆盖、局部截面与限制映射所给出的可比较区域块；
@@ -31,7 +31,7 @@ X_\infty\cong \varprojlim_m X_m.
 \end{proof}
 
 \begin{definition}[时间读出与纤维势]\label{def:physical-spacetime-clock-readout-fiber-potential}
-对任意 \(X\in\operatorname{Ob}(\mathsf T_{\mathrm{ff}})\)，记 \(\lambda_X\) 为其局域时间读出映射，并以 \(\chi\) 表示前文时间投影所固定的公共标量化接口，定义
+对任意 \(X\in\operatorname{Ob}(\mathcal T_{\mathrm{ff}})\)，记 \(\lambda_X\) 为其局域时间读出映射，并以 \(\chi\) 表示前文时间投影所固定的公共标量化接口，定义
 \[
 \tau_X:=\chi\circ\lambda_X.
 \]
@@ -451,6 +451,8 @@ G_{\mu\nu}+\Lambda g_{\mu\nu}=\kappa\,T^{(\mathrm{res})}_{\mu\nu}.
 \begin{proof}
 第一行的链由定义 \ref{def:physical-spacetime-clock-readout-fiber-potential}、定义 \ref{def:physical-spacetime-clock-transport}、定理 \ref{thm:physical-spacetime-clock-transport-equation}、定理 \ref{thm:physical-spacetime-local-clock-potential} 与推论 \ref{cor:physical-spacetime-local-redshift} 给出。第二行的前半段由定义 \ref{def:physical-spacetime-audited-physical-seed}、命题 \ref{prop:physical-spacetime-audited-seed-rank-three}、定义 \ref{def:physical-spacetime-local-space-quadratic-form}、定义 \ref{def:physical-spacetime-seed-chart}、命题 \ref{prop:physical-spacetime-finite-compatible-family-glues} 与定理 \ref{thm:physical-spacetime-global-lorentz-structure} 给出；后半段则由定义 \ref{def:physical-spacetime-global-resource-scalar}、定义 \ref{def:physical-spacetime-derived-stress-energy}、定理 \ref{thm:physical-spacetime-gravitational-scalar-uniqueness} 与定理 \ref{thm:physical-spacetime-admissible-global-einstein-equation} 给出。整条构造只调用本文内部对象、局域 exactness 假设、粘接证书与已审计常数，不额外诉诸项目外信息。故盒中命题成立。证毕。
 \end{proof}
+
+\input{subsubsec__physical-spacetime-skeleton-cech-terminal-cosmological-rigidity}
 
 \begin{remark}[本小节命题的精确边界]\label{rem:physical-spacetime-admissible-einstein-closure-boundary}
 定理 \ref{thm:physical-spacetime-admissible-einstein-closure-main} 解决的是一个经过精确收束后的主命题：内部对象所支持的最大 admissible 四维域 \(M_{\mathrm{adm}}\) 上存在全局 Einstein 理论。对这一命题而言，原先可能造成跳步的环节都已被显式对象化：局域可积性被写成 transport-flat exact patch，时间搬运被写成时钟运输 \(1\)-上链，空间来源被写成审计种子，局域到全局的跃迁被写成粘接证书与 admissible 最大域，场方程闭包被写成最小二阶协变类中的变分唯一性。因而，就该精确定义后的命题而言，本文内部逻辑链已经闭合，不再含有未对象化的内部断裂。

--- a/theory/2026_golden_ratio_driven_scan_projection_generation_recursive_emergence/sections/body/physical_spacetime_skeleton/subsubsec__physical-spacetime-skeleton-cech-terminal-cosmological-rigidity.tex
+++ b/theory/2026_golden_ratio_driven_scan_projection_generation_recursive_emergence/sections/body/physical_spacetime_skeleton/subsubsec__physical-spacetime-skeleton-cech-terminal-cosmological-rigidity.tex
@@ -1,0 +1,253 @@
+\subsubsection{\v{C}ech 平凡化、终端粘接与宇宙学型刚性}
+
+定理 \ref{thm:physical-spacetime-admissible-einstein-closure-main} 给出了 admissible 闭包的存在性命题。在这一存在性之上，还可以进一步抽取三类刚性后果：局域时钟势的 \v{C}ech 平凡化、最大 admissible 域的终端粘接泛性质、以及资源源项退化为宇宙学型项后的弱场正规形。
+
+\begin{theorem}[局域时钟势的 \v{C}ech 余循环结构]\label{thm:physical-spacetime-clock-potential-cech-cocycle}
+设 \(\{U_\alpha\}_{\alpha\in I}\) 是一个 admissible 局域覆盖，并假设每个非空有限交
+\[
+U_{\alpha_0\cdots\alpha_k}:=U_{\alpha_0}\cap\cdots\cap U_{\alpha_k}
+\]
+仍为定义 \ref{def:physical-spacetime-transport-flat-exact-patch} 意义下的 transport-flat exact patch。对每个 \(\alpha\) 取定理 \ref{thm:physical-spacetime-local-clock-potential} 给出的局域时钟势 \(\phi_\alpha\)，使
+\[
+\Theta|_{U_\alpha}=\delta\phi_\alpha.
+\]
+则对任意非空二重交 \(U_{\alpha\beta}\) 存在常数 \(c_{\alpha\beta}\in\RR\) 使
+\[
+\phi_\alpha-\phi_\beta=c_{\alpha\beta}
+\qquad\text{于 }U_{\alpha\beta},
+\]
+并且对任意非空三重交 \(U_{\alpha\beta\gamma}\) 有
+\[
+c_{\alpha\beta}+c_{\beta\gamma}+c_{\gamma\alpha}=0.
+\]
+若记 \(N_\alpha:=e^{-\phi_\alpha}\)，则在 \(U_{\alpha\beta}\) 上有
+\[
+N_\alpha=e^{-c_{\alpha\beta}}N_\beta,
+\]
+因而 \((e^{-c_{\alpha\beta}})\) 构成一个 \(\RR_{>0}\)-值 \v{C}ech \(1\)-余循环。
+\end{theorem}
+\begin{proof}
+在任意非空二重交 \(U_{\alpha\beta}\) 上，
+\[
+\delta\phi_\alpha=\Theta=\delta\phi_\beta,
+\]
+故
+\[
+\delta(\phi_\alpha-\phi_\beta)=0.
+\]
+由于 \(U_{\alpha\beta}\) 仍是 transport-flat exact patch，特别地可缩且连通，故 \(\delta\)-闭的 \(0\)-上链只能是常数，因而存在 \(c_{\alpha\beta}\in\RR\) 使
+\[
+\phi_\alpha-\phi_\beta=c_{\alpha\beta}.
+\]
+在任意非空三重交 \(U_{\alpha\beta\gamma}\) 上，把三组差函数相加即得
+\[
+(\phi_\alpha-\phi_\beta)+(\phi_\beta-\phi_\gamma)+(\phi_\gamma-\phi_\alpha)=0,
+\]
+从而
+\[
+c_{\alpha\beta}+c_{\beta\gamma}+c_{\gamma\alpha}=0.
+\]
+最后，由 \(N_\alpha=e^{-\phi_\alpha}\) 与 \(\phi_\alpha-\phi_\beta=c_{\alpha\beta}\) 立得
+\[
+N_\alpha=e^{-c_{\alpha\beta}}N_\beta.
+\]
+故 \((e^{-c_{\alpha\beta}})\) 满足乘法 \v{C}ech \(1\)-余循环条件。证毕。
+\end{proof}
+
+\begin{corollary}[时钟势与 redshift 因子的全局单值化]\label{cor:physical-spacetime-global-clock-potential}
+在 \(M_{\mathrm{adm}}\) 上，局域时钟势 \(\phi_\alpha\) 可粘接为全局函数
+\[
+\phi:M_{\mathrm{adm}}\to\RR,
+\]
+并且
+\[
+N:=e^{-\phi}
+\]
+是全局定义的正函数。于是对任意两点 \(A,B\in M_{\mathrm{adm}}\)，同一脉冲的频率比由唯一公式给出
+\[
+\frac{\nu_B}{\nu_A}=\frac{N(A)}{N(B)}=e^{\phi(A)-\phi(B)},
+\]
+且与所选 admissible 图链无关。
+\end{corollary}
+\begin{proof}
+取 \(M_{\mathrm{adm}}\) 的 admissible 图册的一个满足定理 \ref{thm:physical-spacetime-clock-potential-cech-cocycle} 假设的 good refinement，并在其上应用该定理。由定义 \ref{def:physical-spacetime-gluing-compatibility}，admissible 过渡映射在重叠区上保持 \(\phi\) 与 \(N\) 的局域表达同一性。另一方面，定理 \ref{thm:physical-spacetime-clock-potential-cech-cocycle} 表明
+\[
+\phi_\alpha-\phi_\beta=c_{\alpha\beta},
+\qquad
+N_\alpha=e^{-c_{\alpha\beta}}N_\beta.
+\]
+若 \(N_\alpha\) 与 \(N_\beta\) 代表同一几何对象，则必有 \(e^{-c_{\alpha\beta}}=1\)，于是 \(c_{\alpha\beta}=0\)。故所有局域 \(\phi_\alpha\) 在重叠上严格相等，从而粘接成全局函数 \(\phi\)，\(N=e^{-\phi}\) 亦因此全局良定。再由推论 \ref{cor:physical-spacetime-local-redshift} 的局域 redshift 公式，即得全局频率比表达式。证毕。
+\end{proof}
+
+\begin{theorem}[最大 admissible 域的终端粘接泛性质]\label{thm:physical-spacetime-terminal-admissible-domain}
+设 \(\mathfrak C_\ast\) 为由审计种子图 \(C_\ast\) 经有限次可粘接相容拼接所得的全部 \(4\)-维 \(C^2\) Lorentz 图册所成范畴，其态射取保持 \((t,x,\phi,N,g)\) 的局域 \(C^2\)-同构。则 \(M_{\mathrm{adm}}\) 是 \(\mathfrak C_\ast\) 中的终端对象：对任意 \(\mathcal U\in\operatorname{Ob}(\mathfrak C_\ast)\)，存在唯一态射
+\[
+\iota_{\mathcal U}:\mathcal U\longrightarrow M_{\mathrm{adm}}.
+\]
+\end{theorem}
+\begin{proof}
+定义 \ref{def:physical-spacetime-maximal-admissible-domain} 已把
+\[
+M_{\mathrm{adm}}
+\]
+规定为所有由审计种子图经有限次 admissible 粘接所得局域图的并，并按重叠相容关系取商。因而任一 \(\mathcal U\in\mathfrak C_\ast\) 本身就是该并中的一个代表，其到商空间的自然商映射给出一条态射
+\[
+\iota_{\mathcal U}:\mathcal U\to M_{\mathrm{adm}}.
+\]
+由命题 \ref{prop:physical-spacetime-finite-compatible-family-glues}，有限相容族的粘接在局域 \(C^2\) Lorentz 图册意义下唯一；故任何从 \(\mathcal U\) 到 \(M_{\mathrm{adm}}\) 的态射在每个局域图块上都必须与该商识别一致，从而只能等于 \(\iota_{\mathcal U}\)。于是 \(M_{\mathrm{adm}}\) 为终端对象。证毕。
+\end{proof}
+
+\begin{corollary}[最大 admissible Einstein 域的唯一性]\label{cor:physical-spacetime-maximal-domain-uniqueness}
+若 \(\mathcal M_1,\mathcal M_2\) 由同一审计种子 \(p_\ast\) 与同一 admissible 粘接规则生成，则存在唯一 \(C^2\)-等距同构
+\[
+\Psi:\mathcal M_1\xrightarrow{\cong}\mathcal M_2
+\]
+保持全部结构
+\[
+(t,x,\phi,N,g,\nabla,R,\mathrm{Ric},R_g,G).
+\]
+\end{corollary}
+\begin{proof}
+由定理 \ref{thm:physical-spacetime-terminal-admissible-domain}，\(\mathcal M_1\) 与 \(\mathcal M_2\) 都是同一范畴 \(\mathfrak C_\ast\) 的终端对象。终端对象在同构意义下唯一，因此存在唯一同构
+\[
+\Psi:\mathcal M_1\xrightarrow{\cong}\mathcal M_2.
+\]
+按态射定义，\(\Psi\) 保持 \((t,x,\phi,N,g)\)；而 \(\nabla,R,\mathrm{Ric},R_g,G\) 全都由定义 \ref{def:physical-spacetime-global-curvature-objects} 通过 \(g\) 唯一诱导，因此亦被 \(\Psi\) 保持。证毕。
+\end{proof}
+
+\begin{theorem}[资源应力的纯迹化]\label{thm:physical-spacetime-resource-stress-energy-pure-trace}
+导出应力--能量张量满足严格公式
+\[
+T^{(\mathrm{res})}_{\mu\nu}=\mathcal L_{\mathrm{res}}\,g_{\mu\nu}.
+\]
+特别地，其无迹部分恒为零：
+\[
+T^{(\mathrm{res})}_{\mu\nu}
+-\frac14\bigl(T^{(\mathrm{res})}\bigr)^\lambda{}_\lambda\,g_{\mu\nu}=0.
+\]
+\end{theorem}
+\begin{proof}
+由命题 \ref{prop:physical-spacetime-resource-scalar-well-defined}，\(\mathcal L_{\mathrm{res}}\) 是全局常数，因此
+\[
+\int_{M_{\mathrm{adm}}}\mathcal L_{\mathrm{res}}\,d\mathrm{Vol}_g
+=
+\int_{M_{\mathrm{adm}}}\mathcal L_{\mathrm{res}}\sqrt{\lvert g\rvert}\,dx.
+\]
+对 \(g^{\mu\nu}\) 作变分时，
+\[
+\delta\sqrt{\lvert g\rvert}
+=-\frac12\sqrt{\lvert g\rvert}\,g_{\mu\nu}\,\delta g^{\mu\nu},
+\]
+于是
+\[
+\delta\!\int_{M_{\mathrm{adm}}}\mathcal L_{\mathrm{res}}\sqrt{\lvert g\rvert}\,dx
+=
+-\frac12
+\int_{M_{\mathrm{adm}}}\mathcal L_{\mathrm{res}}\sqrt{\lvert g\rvert}\,g_{\mu\nu}\,\delta g^{\mu\nu}\,dx.
+\]
+代回定义 \ref{def:physical-spacetime-derived-stress-energy}，便得到
+\[
+T^{(\mathrm{res})}_{\mu\nu}=\mathcal L_{\mathrm{res}}\,g_{\mu\nu}.
+\]
+再取迹即可看出其无迹部分恒为零。证毕。
+\end{proof}
+
+\begin{corollary}[admissible Einstein 闭包的真空化]\label{cor:physical-spacetime-effective-cosmological-closure}
+定义有效宇宙学常数
+\[
+\Lambda_{\mathrm{eff}}:=\Lambda-\kappa\mathcal L_{\mathrm{res}}.
+\]
+则定理 \ref{thm:physical-spacetime-admissible-global-einstein-equation} 的场方程化为
+\[
+G_{\mu\nu}+\Lambda_{\mathrm{eff}}g_{\mu\nu}=0.
+\]
+在四维情形下，这进一步等价于
+\[
+\mathrm{Ric}_{\mu\nu}=\Lambda_{\mathrm{eff}}g_{\mu\nu},
+\qquad
+R_g=4\Lambda_{\mathrm{eff}}.
+\]
+\end{corollary}
+\begin{proof}
+由定理 \ref{thm:physical-spacetime-resource-stress-energy-pure-trace}，
+\[
+T^{(\mathrm{res})}_{\mu\nu}=\mathcal L_{\mathrm{res}}\,g_{\mu\nu}.
+\]
+把它代入定理 \ref{thm:physical-spacetime-admissible-global-einstein-equation} 即得
+\[
+G_{\mu\nu}+\Lambda g_{\mu\nu}
+=
+\kappa\mathcal L_{\mathrm{res}}\,g_{\mu\nu},
+\]
+整理后即为
+\[
+G_{\mu\nu}+\Lambda_{\mathrm{eff}}g_{\mu\nu}=0.
+\]
+再对该式取迹。四维中有
+\[
+G^\mu{}_\mu=-R_g,
+\]
+故
+\[
+-R_g+4\Lambda_{\mathrm{eff}}=0,
+\qquad
+R_g=4\Lambda_{\mathrm{eff}}.
+\]
+把此式代回
+\[
+G_{\mu\nu}=\mathrm{Ric}_{\mu\nu}-\frac12R_g g_{\mu\nu}
+\]
+便得到
+\[
+\mathrm{Ric}_{\mu\nu}=\Lambda_{\mathrm{eff}}g_{\mu\nu}.
+\]
+证毕。
+\end{proof}
+
+\begin{theorem}[静态弱场势的二次--调和正规形]\label{thm:physical-spacetime-weak-field-quadratic-harmonic-normal-form}
+在推论 \ref{cor:physical-spacetime-weak-field-redshift-potential} 的静态弱场制度下，把其中的比例常数记为 \(\sigma_\ast\)，即
+\[
+\Delta_{h_\ast}\phi=\sigma_\ast\mathcal L_{\mathrm{res}}.
+\]
+若线性化闭包采用非退化归一化，则 \(\sigma_\ast\neq 0\)。于是对任意 \(h_\ast\)-正交坐标 \(y=(y^1,y^2,y^3)\)，每个局域弱场解都唯一写成
+\[
+\phi(y)=\frac{\sigma_\ast\mathcal L_{\mathrm{res}}}{6}\lvert y\rvert^2+h(y),
+\qquad
+\Delta h=0.
+\]
+\end{theorem}
+\begin{proof}
+在 \(h_\ast\)-正交坐标中，\(\Delta_{h_\ast}\) 就是标准 Laplace 算子 \(\Delta\)。又因
+\[
+\Delta\lvert y\rvert^2=6,
+\]
+可知
+\[
+\Delta\!\left(\frac{\sigma_\ast\mathcal L_{\mathrm{res}}}{6}\lvert y\rvert^2\right)
+=
+\sigma_\ast\mathcal L_{\mathrm{res}}.
+\]
+因此若 \(\phi\) 满足
+\[
+\Delta\phi=\sigma_\ast\mathcal L_{\mathrm{res}},
+\]
+则
+\[
+h(y):=\phi(y)-\frac{\sigma_\ast\mathcal L_{\mathrm{res}}}{6}\lvert y\rvert^2
+\]
+满足 \(\Delta h=0\)。反之，任意调和函数 \(h\) 都给出一个解。Poisson 方程解空间因此是一个以调和函数空间为平移方向的仿射空间，从而上述分解唯一。证毕。
+\end{proof}
+
+\begin{corollary}[内部源项的宇宙学型刚性]\label{cor:physical-spacetime-no-localized-matter-source}
+在最小二阶协变引力闭包与固定审计种子 \(p_\ast\) 的制度下，由本文内部数据导出的源项只有宇宙学型分量。更精确地说：
+\begin{enumerate}
+  \item \(T^{(\mathrm{res})}_{\mu\nu}\) 的无迹部分恒为零，因而不存在内部生成的各向异性应力；
+  \item admissible 场方程等价于真空 Einstein--\(\Lambda_{\mathrm{eff}}\) 方程，因而不存在独立于 \(g_{\mu\nu}\) 的额外物质型张量结构；
+  \item 静态弱场中的源项为空间常数 \(\sigma_\ast\mathcal L_{\mathrm{res}}\)，故局域自由度只剩调和边界数据，不能在内部闭包中形成真正局域化的质量团簇。
+\end{enumerate}
+\end{corollary}
+\begin{proof}
+第一条直接来自定理 \ref{thm:physical-spacetime-resource-stress-energy-pure-trace}。第二条由推论 \ref{cor:physical-spacetime-effective-cosmological-closure} 给出。第三条则由定理 \ref{thm:physical-spacetime-weak-field-quadratic-harmonic-normal-form} 立得：弱场势的局域解完全由一个固定二次核与一个调和边界项组成，内部源项本身并不携带局域化质量分布所需的空间变化。证毕。
+\end{proof}
+
+上述结果表明，本小节的 admissible 闭包并不止于存在性命题。transport-flat exact patch 上的局域时钟势首先形成加法 \v{C}ech \(1\)-余循环，而 admissible 相容性随后迫使该余循环平凡化，于是 \(M_{\mathrm{adm}}\) 同时获得全局单值的 redshift 势与终端粘接泛性质。另一方面，\(\mathcal L_{\mathrm{res}}\) 的常数性把资源应力压缩为纯迹项，从而把 admissible Einstein 闭包进一步收束为真空 Einstein--\(\Lambda_{\mathrm{eff}}\) 系统；在线性弱场极限中，这一收束又具体表现为二次核与调和边界数据的严格分离。


### PR DESCRIPTION
## Summary
- add a new conclusion subsection for window-6 boundary parity detector rigidity and side-information bounds
- record faithful detector lower bounds on disconnected components under rational and geometric blindness constraints
- add reconstruction-cost lower bounds with boundary superselection side information
- formalize the blindness of the algebra generated by `F_8` repair data and rational continuous certificates
- add a cross-scale parity re-locking conjecture via a `2`-primary stack with external registers
- wire the new subsection into the conclusion `main.tex` input list

## Testing
- Not run (not requested)